### PR TITLE
Implement RouteCore::view() method

### DIFF
--- a/src/Http/Routing/RouteCore.php
+++ b/src/Http/Routing/RouteCore.php
@@ -75,6 +75,20 @@ class RouteCore
     {
         return self::createRoute($path, ["POST"], $action);
     }
+    
+    /**
+     * Creates GET route directly returning view
+     *
+     * @param string $path
+     * @param ?string $view
+     *
+     * @return Route
+     */
+    public static function view(string $path, string $view = null)
+    {
+        $view = $view ?? str_replace('/', '.', $path);
+        return self::createRoute($path, ["GET"], fn() => view($view));
+    }
 
     /**
      * Creates route for every request method


### PR DESCRIPTION
`RouteCore::view()` method allows you to return view directly from GET route definition method. It also allows you to use only one argument, when URI is matching path to view (with `/` changed to `.`).