### PR TITLE
Optional http error handlers

### DIFF
--- a/src/Lemon/Cache.php
+++ b/src/Lemon/Cache.php
@@ -7,17 +7,17 @@ namespace Lemon;
 /**
  * Static layer over Lemon Cache.
  *
- * @method static void load()                                                            Cached data.
- * @method static array data()                                                           Returns cached data.
- * @method static mixed get(string $key, mixed $default = null)                          Returns cached value or default value.
- * @method static bool set(string $key, mixed $value, null|DateInterval|int $ttl = null) Sets new value to cache.
- * @method static bool delete(string $key)                                               Removes value from cache.
- * @method static bool clear()                                                           Clears cache.
- * @method static iterable getMultiple(iterable $keys, mixed $default = null)            Returns value for every given key.
- * @method static bool deleteMultiple(iterable $keys)                                    Removes item for every given key.
- * @method static bool setMultiple(iterable $values, null|DateInterval|int $ttl = null)  Sets multiple items.
- * @method static bool has(string $key)                                                  Returns whenever key exist.
- * @method static bool commit()                                                          Saves data to file.
+ * @method static void     load()                                                            Cached data.
+ * @method static array    data()                                                            Returns cached data.
+ * @method static mixed    get(string $key, mixed $default = null)                           Returns cached value or default value.
+ * @method static bool     set(string $key, mixed $value, null|DateInterval|int $ttl = null) Sets new value to cache.
+ * @method static bool     delete(string $key)                                               Removes value from cache.
+ * @method static bool     clear()                                                           Clears cache.
+ * @method static iterable getMultiple(iterable $keys, mixed $default = null)                Returns value for every given key.
+ * @method static bool     deleteMultiple(iterable $keys)                                    Removes item for every given key.
+ * @method static bool     setMultiple(iterable $values, null|DateInterval|int $ttl = null)  Sets multiple items.
+ * @method static bool     has(string $key)                                                  Returns whenever key exist.
+ * @method static bool     commit()                                                          Saves data to file.
  *
  * @see \Lemon\Cache\Cache
  */

--- a/src/Lemon/Cache/Cache.php
+++ b/src/Lemon/Cache/Cache.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Cache;
 
-use DateInterval;
-use DateTime;
 use Lemon\Cache\Exceptions\InvalidArgumentException;
 use Lemon\Contracts\Cache\Cache as CacheContract;
 use Lemon\Contracts\Config\Config;
@@ -104,7 +102,7 @@ class Cache implements CacheContract
     /**
      * Sets new value to cache.
      */
-    public function set(string $key, mixed $value, null|int|DateInterval $ttl = null): bool
+    public function set(string $key, mixed $value, null|int|\DateInterval $ttl = null): bool
     {
         $expires_at = null;
         if ($ttl) {
@@ -113,8 +111,8 @@ class Cache implements CacheContract
                     throw new InvalidArgumentException('TTL must be bigger than 0');
                 }
             }
-            $expires_at = new DateTime('@'.$this->time);
-            $ttl = $ttl instanceof DateInterval ? $ttl : new DateInterval("PT{$ttl}S");
+            $expires_at = new \DateTime('@'.$this->time);
+            $ttl = $ttl instanceof \DateInterval ? $ttl : new \DateInterval("PT{$ttl}S");
             $expires_at = $expires_at->add($ttl)->getTimestamp();
         }
         $this->data[$key] = ['value' => $value, 'expires_at' => $expires_at];
@@ -179,7 +177,7 @@ class Cache implements CacheContract
     /**
      * Sets multiple items.
      */
-    public function setMultiple(iterable $values, null|int|DateInterval $ttl = null): bool
+    public function setMultiple(iterable $values, null|int|\DateInterval $ttl = null): bool
     {
         foreach ($values as $key => $value) {
             if (!is_string($key)) {

--- a/src/Lemon/Cache/Exceptions/CacheException.php
+++ b/src/Lemon/Cache/Exceptions/CacheException.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Lemon\Cache\Exceptions;
 
-use Exception;
 use Psr\SimpleCache\CacheException as PsrCacheException;
 
-class CacheException extends Exception implements PsrCacheException
+class CacheException extends \Exception implements PsrCacheException
 {
 }

--- a/src/Lemon/Config.php
+++ b/src/Lemon/Config.php
@@ -7,12 +7,12 @@ namespace Lemon;
 /**
  * Static layer over Lemon Config.
  *
- * @method static static load(string $directory = 'config')                                                    Loads config data from given directory.
- * @method static mixed get(string $key)                                                                       Returns value for given key in config
- * @method static string file(string $key, string $extension = null)                                           Returns project file for given key in config.
- * @method static static set(string $key, mixed $value)                                                        Sets key in config for given value.
- * @method static void loadPart(string $part, bool $force = false) Loads part (if not loaded or force is true) into static::$data.
- * @method static array data()                                                                                 Returns all config data
+ * @method static static load(string $directory = 'config')                                                      Loads config data from given directory.
+ * @method static mixed  get(string $key)                                                                        Returns value for given key in config
+ * @method static string file(string $key, string $extension = null)                                             Returns project file for given key in config.
+ * @method static static set(string $key, mixed $value)                                                          Sets key in config for given value.
+ * @method static void   loadPart(string $part, bool $force = false) Loads part (if not loaded or force is true) into static::$data.
+ * @method static array  data()                                                                                  Returns all config data
  *
  * @see \Lemon\Config\Config
  */

--- a/src/Lemon/Config/Exceptions/ConfigException.php
+++ b/src/Lemon/Config/Exceptions/ConfigException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Config\Exceptions;
 
-use Exception;
-
-class ConfigException extends Exception
+class ConfigException extends \Exception
 {
 }

--- a/src/Lemon/Contracts/Database/Database.php
+++ b/src/Lemon/Contracts/Database/Database.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Lemon\Contracts\Database;
 
 use Lemon\Database\Drivers\Driver;
-use PDOStatement;
 
 interface Database
 {
@@ -19,5 +18,5 @@ interface Database
      *
      * @phpstan-param literal-string $query
      */
-    public function query(string $query, ...$params): PDOStatement;
+    public function query(string $query, ...$params): \PDOStatement;
 }

--- a/src/Lemon/Contracts/Debug/Handler.php
+++ b/src/Lemon/Contracts/Debug/Handler.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Lemon\Contracts\Debug;
 
-use Exception;
-
 interface Handler
 {
     /**
      * Executes handler depending on debug settings.
      */
-    public function handle(Exception $problem): void;
+    public function handle(\Exception $problem): void;
 }

--- a/src/Lemon/Contracts/Terminal/Terminal.php
+++ b/src/Lemon/Contracts/Terminal/Terminal.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Contracts\Terminal;
 
-use Closure;
 use Lemon\Terminal\Commands\Command;
 
 interface Terminal
@@ -12,7 +11,7 @@ interface Terminal
     /**
      * Creates new command.
      */
-    public function command(string $signature, Closure $action, string $description = ''): Command;
+    public function command(string $signature, \Closure $action, string $description = ''): Command;
 
     /**
      * Outputs given content.

--- a/src/Lemon/Csrf.php
+++ b/src/Lemon/Csrf.php
@@ -8,9 +8,9 @@ namespace Lemon;
  * Lemon Csrf Zest
  * Provides static layer over the Lemon Csrf.
  *
- * @method static string getToken()            Returns csrf token and creates new if does not exist
- * @method static void reset()                 Removes token from cookies
- * @method static bool validate(string $token) Returns whenever given token equals token in cookies
+ * @method static string getToken()              Returns csrf token and creates new if does not exist
+ * @method static void   reset()                 Removes token from cookies
+ * @method static bool   validate(string $token) Returns whenever given token equals token in cookies
  *
  * @see \Lemon\Protection\Csrf
  */

--- a/src/Lemon/DB.php
+++ b/src/Lemon/DB.php
@@ -8,9 +8,9 @@ namespace Lemon;
  * Lemon DB Zest
  * Provides static layer over the Lemon Database.
  *
- * @method static \Lemon\Database\Driver getConnection()        Returns current driver and creates new if isn't already.
- * @method static void connect()                                Creates new Driver and connects to database.
- * @method static PDOStatement query(string $query, ...$params) Sends query to database.
+ * @method static \Lemon\Database\Driver getConnection()                  Returns current driver and creates new if isn't already.
+ * @method static void                   connect()                        Creates new Driver and connects to database.
+ * @method static PDOStatement           query(string $query, ...$params) Sends query to database.
  *
  * @see \Lemon\Database\Database
  */

--- a/src/Lemon/Database/Database.php
+++ b/src/Lemon/Database/Database.php
@@ -7,7 +7,6 @@ namespace Lemon\Database;
 use Lemon\Contracts\Config\Config;
 use Lemon\Contracts\Database\Database as DatabaseContract;
 use Lemon\Database\Drivers\Driver;
-use PDOStatement;
 
 class Database implements DatabaseContract
 {
@@ -41,7 +40,7 @@ class Database implements DatabaseContract
      *
      * @phpstan-param literal-string $query
      */
-    public function query(string $query, ...$params): PDOStatement
+    public function query(string $query, ...$params): \PDOStatement
     {
         $statement = $this->getConnection()->prepare($query);
         $statement->execute($params);

--- a/src/Lemon/Database/Drivers/Driver.php
+++ b/src/Lemon/Database/Drivers/Driver.php
@@ -7,7 +7,7 @@ namespace Lemon\Database\Drivers;
 use Lemon\Config\Config;
 use PDO;
 
-abstract class Driver extends PDO
+abstract class Driver extends \PDO
 {
     public function __construct(
         public readonly Config $config

--- a/src/Lemon/Debug.php
+++ b/src/Lemon/Debug.php
@@ -10,7 +10,7 @@ namespace Lemon;
  *
  * @method static string resolve(mixed $data) Resolves parsing method depending on datatype.
  * @method static string build(mixed $data)   Builds html for dumper.
- * @method static void dump(mixed $data)      Dumps given data.
+ * @method static void   dump(mixed $data)    Dumps given data.
  *
  * @see \Lemon\Debug\Dumper
  */

--- a/src/Lemon/Debug/Dumper.php
+++ b/src/Lemon/Debug/Dumper.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Debug;
 
-use Closure;
 use Lemon\Contracts\Config\Config;
 use Lemon\Contracts\Debug\Dumper as DumperContract;
 use Lemon\Debug\Exceptions\DebugerException;
@@ -104,7 +103,7 @@ class Dumper implements DumperContract
 
         // This allows us to get private properties in dumped object.
         // Don't use this exploit in production.
-        $result .= Closure::fromCallable(function (Dumper $dumper) {
+        $result .= \Closure::fromCallable(function (Dumper $dumper) {
             $result = '';
             foreach (get_class_vars($this::class) as $property => $_) {
                 $result .= '<span class="ldg-property"><span class="ldg-property-name">'.$property.'</span> => '.$dumper->resolve($this->{$property} ?? null).'</span>';

--- a/src/Lemon/Debug/Exceptions/DebugerException.php
+++ b/src/Lemon/Debug/Exceptions/DebugerException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Debug\Exceptions;
 
-use Exception;
-
-class DebugerException extends Exception
+class DebugerException extends \Exception
 {
 }

--- a/src/Lemon/Debug/Handling/Handler.php
+++ b/src/Lemon/Debug/Handling/Handler.php
@@ -8,7 +8,6 @@ use Lemon\Config\Config;
 use Lemon\Http\ResponseFactory;
 use Lemon\Kernel\Application;
 use Lemon\Logging\Logger;
-use Throwable;
 
 class Handler
 {
@@ -23,7 +22,7 @@ class Handler
     /**
      * Executes handler depending on debug settings.
      */
-    public function handle(Throwable $problem): void
+    public function handle(\Throwable $problem): void
     {
         if ($this->application->runsInTerminal()) {
             echo $problem;

--- a/src/Lemon/Debug/Handling/Reporter.php
+++ b/src/Lemon/Debug/Handling/Reporter.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Lemon\Debug\Handling;
 
-use ErrorException;
 use Lemon\Http\Request;
 use Lemon\Http\Responses\TemplateResponse;
 use Lemon\Kernel\Application;
 use Lemon\Templating\Template;
-use Throwable;
 
 class Reporter
 {
@@ -18,7 +16,7 @@ class Reporter
     private Consultant $consultant;
 
     public function __construct(
-        private Throwable $exception,
+        private \Throwable $exception,
         private Request $request,
         private Application $application
     ) {
@@ -44,7 +42,7 @@ class Reporter
         $problem = $this->exception;
 
         return [
-            'problem' => $problem instanceof ErrorException
+            'problem' => $problem instanceof \ErrorException
                          ? $this->severityToString($problem->getSeverity())
                          : $problem::class,
             'file' => str_replace($this->application->directory, '', $problem->getFile()),

--- a/src/Lemon/Env.php
+++ b/src/Lemon/Env.php
@@ -8,13 +8,13 @@ namespace Lemon;
  * Lemon Env Zest
  * Provides static layer over the Lemon Env.
  *
- * @method static void load()                                                     Loads env file
- * @method static mixed get(string $key, mixed $default = null)                   Returns env value of given key or default if not present
+ * @method static void   load()                                                   Loads env file
+ * @method static mixed  get(string $key, mixed $default = null)                  Returns env value of given key or default if not present
  * @method static string file(string $key, string $prefix, mixed $default = null) Returns file with name from env
- * @method static bool has(string $key)                                           Returns whenever env key exist
- * @method static void set(string $key, string $value)                            Sets env key with given value
- * @method static array data()                                                    Returns env data
- * @method static void commit()                                                   Saves data back to env file
+ * @method static bool   has(string $key)                                         Returns whenever env key exist
+ * @method static void   set(string $key, string $value)                          Sets env key with given value
+ * @method static array  data()                                                   Returns env data
+ * @method static void   commit()                                                 Saves data back to env file
  *
  * @see \Lemon\Support\Env
  */

--- a/src/Lemon/Event.php
+++ b/src/Lemon/Event.php
@@ -10,7 +10,7 @@ namespace Lemon;
  *
  * @method static static on(string $name, callable $action) Registers event handling function
  * @method static static fire(string $name, mixed ...$args) Calls all event handling functions with given arguments
- * @method static array events()                            Returns all events
+ * @method static array  events()                           Returns all events
  *
  * @see \Lemon\Events\Dispatcher
  */

--- a/src/Lemon/Http/Exceptions/CookieException.php
+++ b/src/Lemon/Http/Exceptions/CookieException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Http\Exceptions;
 
-use Exception;
-
-class CookieException extends Exception
+class CookieException extends \Exception
 {
 }

--- a/src/Lemon/Http/Exceptions/SessionException.php
+++ b/src/Lemon/Http/Exceptions/SessionException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Http\Exceptions;
 
-use Exception;
-
-class SessionException extends Exception
+class SessionException extends \Exception
 {
 }

--- a/src/Lemon/Http/Request.php
+++ b/src/Lemon/Http/Request.php
@@ -35,7 +35,7 @@ class Request
             return $result;
         }
 
-        throw new Exception('Property '.$name.' does not exist');
+        throw new \Exception('Property '.$name.' does not exist');
     }
 
     /**
@@ -168,12 +168,12 @@ class Request
     /**
      * Determins whenever request meets given rules.
      *
-     * @throws Exception When application is not injected
+     * @throws \Exception When application is not injected
      */
     public function validate(array $rules): bool
     {
         if (!$this->application) {
-            throw new Exception('Application is required for validation. Try injecting using ::injectApplication'); // TODO exception
+            throw new \Exception('Application is required for validation. Try injecting using ::injectApplication'); // TODO exception
         }
 
         return $this->application->get(Validator::class)

--- a/src/Lemon/Http/Response.php
+++ b/src/Lemon/Http/Response.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Http;
 
-use DateTime;
-use DateTimeInterface;
-
 /**
  * Represents Http Response.
  *
@@ -89,8 +86,8 @@ abstract class Response
         foreach ($this->cookies as [$name, $cookie, $expire]) {
             $header = "{$name}={$cookie}";
             if ($expire) {
-                $expires = new DateTime();
-                $expires = $expires->setTimestamp($expire)->format(DateTimeInterface::RFC7231);
+                $expires = new \DateTime();
+                $expires = $expires->setTimestamp($expire)->format(\DateTimeInterface::RFC7231);
                 $header .= ' Expires='.$expires;
             }
             $this->header('Set-Cookie', $header);

--- a/src/Lemon/Http/ResponseFactory.php
+++ b/src/Lemon/Http/ResponseFactory.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Http;
 
-use Exception;
-use InvalidArgumentException;
 use Lemon\Contracts\Http\Jsonable;
 use Lemon\Contracts\Http\ResponseFactory as ResponseFactoryContract;
 use Lemon\Contracts\Templating\Factory as Templating;
@@ -65,7 +63,7 @@ class ResponseFactory implements ResponseFactoryContract
             return new TemplateResponse($data);
         }
 
-        throw new Exception('Class '.$data::class.' can\'t be resolved as response');
+        throw new \Exception('Class '.$data::class.' can\'t be resolved as response');
     }
 
     /**
@@ -74,11 +72,13 @@ class ResponseFactory implements ResponseFactoryContract
     public function error(int $code): Response
     {
         if (!isset(Response::STATUS_CODES[$code]) || $code < 400) {
-            throw new InvalidArgumentException('Status code '.$code.' is not error status code');
+            throw new \InvalidArgumentException('Status code '.$code.' is not error status code');
         }
 
         if (isset($this->handlers[$code])) {
-            return $this->make($this->handlers[$code]);
+            if (!($response = $this->make($this->handlers[$code])) instanceof EmptyResponse) {
+                return $response;
+            }
         }
 
         if ($this->templating->exist("errors.{$code}")) {

--- a/src/Lemon/Juice.php
+++ b/src/Lemon/Juice.php
@@ -8,8 +8,8 @@ namespace Lemon;
  * Lemon Juice Zest
  * Provides static layer over the Lemon Juice engine.
  *
- * @method static string compile(string $template)                                                   Compiles Juice Templates.
- * @method static string getExtension()                                                              Returns file exception
+ * @method static string                           compile(string $template)                         Compiles Juice Templates.
+ * @method static string                           getExtension()                                    Returns file exception
  * @method static \Lemon\Templating\Juice\Compiler addDirectiveCompiler(string $name, string $class) Adds directive compiler class.
  *
  * @see \Lemon\Templating\Juice\Compiler

--- a/src/Lemon/Kernel/Application.php
+++ b/src/Lemon/Kernel/Application.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Lemon\Kernel;
 
 use Error;
-use ErrorException;
 use Exception;
 use Lemon\Contracts;
 use Lemon\Http\Request;
@@ -13,7 +12,6 @@ use Lemon\Protection\Middlwares\Csrf;
 use Lemon\Routing\Router;
 use Lemon\Support\Filesystem;
 use Lemon\Zest;
-use Throwable;
 
 /**
  * The Lemon Application.
@@ -81,7 +79,7 @@ final class Application extends Container
     public function __get(string $name): object
     {
         if (!$this->has($name)) {
-            throw new Exception('Undefined property: '.self::class.'::$'.$name);
+            throw new \Exception('Undefined property: '.self::class.'::$'.$name);
         }
 
         return $this->get($name);
@@ -121,7 +119,7 @@ final class Application extends Container
     /**
      * Executes error handler.
      */
-    public function handle(Throwable $problem): void
+    public function handle(\Throwable $problem): void
     {
         $this->get('handler')->handle($problem);
 
@@ -133,7 +131,7 @@ final class Application extends Container
      */
     public function handleError(int $severity, string $error, string $file, int $line): bool
     {
-        throw new ErrorException($error, 0, $severity, $file, $line);
+        throw new \ErrorException($error, 0, $severity, $file, $line);
     }
 
     /**
@@ -176,7 +174,7 @@ final class Application extends Container
     {
         try {
             $this->get('routing')->dispatch($this->get(Request::class))->send();
-        } catch (Exception|Error $e) {
+        } catch (\Exception|\Error $e) {
             $this->handle($e);
         }
     }

--- a/src/Lemon/Kernel/Commands.php
+++ b/src/Lemon/Kernel/Commands.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Kernel;
 
-use Closure;
 use Lemon\Config\Config;
 use Lemon\Support\Filesystem;
 use Lemon\Templating\Template;
@@ -36,7 +35,7 @@ class Commands
     public function load(): void
     {
         foreach (self::COMMANDS as $command) {
-            $this->terminal->command($command[0], Closure::fromCallable([$this, $command[1]]), $command[2]);
+            $this->terminal->command($command[0], \Closure::fromCallable([$this, $command[1]]), $command[2]);
         }
     }
 

--- a/src/Lemon/Kernel/Container.php
+++ b/src/Lemon/Kernel/Container.php
@@ -7,9 +7,6 @@ namespace Lemon\Kernel;
 use Lemon\Kernel\Exceptions\ContainerException;
 use Lemon\Kernel\Exceptions\NotFoundException;
 use Psr\Container\ContainerInterface;
-use ReflectionClass;
-use ReflectionFunction;
-use ReflectionMethod;
 
 // TODO add application
 class Container implements ContainerInterface
@@ -106,7 +103,7 @@ class Container implements ContainerInterface
 
     public function call(callable $callback, array $params): mixed
     {
-        $fn = is_array($callback) ? new ReflectionMethod(...$callback) : new ReflectionFunction($callback);
+        $fn = is_array($callback) ? new \ReflectionMethod(...$callback) : new \ReflectionFunction($callback);
         $injected = [];
         foreach ($fn->getParameters() as $param) {
             if ($class = (string) $param->getType()) {
@@ -138,7 +135,7 @@ class Container implements ContainerInterface
      */
     private function make(string $service): mixed
     {
-        $class = new ReflectionClass($service);
+        $class = new \ReflectionClass($service);
         $constructor = $class->getConstructor();
 
         if (!$constructor) {

--- a/src/Lemon/Kernel/Exceptions/ContainerException.php
+++ b/src/Lemon/Kernel/Exceptions/ContainerException.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Lemon\Kernel\Exceptions;
 
-use Exception;
 use Psr\Container\ContainerExceptionInterface;
 
-class ContainerException extends Exception implements ContainerExceptionInterface
+class ContainerException extends \Exception implements ContainerExceptionInterface
 {
 }

--- a/src/Lemon/Kernel/Exceptions/LifecycleException.php
+++ b/src/Lemon/Kernel/Exceptions/LifecycleException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Kernel\Exceptions;
 
-use Exception;
-
-class ApplicationException extends Exception
+class ApplicationException extends \Exception
 {
 }

--- a/src/Lemon/Log.php
+++ b/src/Lemon/Log.php
@@ -8,8 +8,8 @@ namespace Lemon;
  * Lemon Logger Zest
  * Provides static layer over the Lemon log.
  *
- * @method static void log($level, string|Stringable $message, array $context = []) {@inheritdoc}
- * @method static string interpolate(string $message, array $context)               Compiles message with given context
+ * @method static void   log($level, string|Stringable $message, array $context = []) {@inheritdoc}
+ * @method static string interpolate(string $message, array $context)                 Compiles message with given context
  *
  * @see \Lemon\Logging\Logger
  */

--- a/src/Lemon/Logging/Logger.php
+++ b/src/Lemon/Logging/Logger.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Lemon\Logging;
 
-use DateTime;
 use Lemon\Contracts\Config\Config;
 use Lemon\Contracts\Logging\Logger as LoggerContract;
 use Lemon\Support\Filesystem;
 use Psr\Log\AbstractLogger;
 use Psr\Log\InvalidArgumentException;
 use Psr\Log\LogLevel;
-use Stringable;
 
 class Logger extends AbstractLogger implements LoggerContract
 {
@@ -26,7 +24,7 @@ class Logger extends AbstractLogger implements LoggerContract
     /**
      * {@inheritdoc}
      */
-    public function log($level, string|Stringable $message, array $context = []): void
+    public function log($level, string|\Stringable $message, array $context = []): void
     {
         $level = strtoupper($level);
         if (!defined(LogLevel::class.'::'.$level)) {
@@ -34,7 +32,7 @@ class Logger extends AbstractLogger implements LoggerContract
         }
         $message = $this->interpolate((string) $message, $context);
 
-        $now = (new DateTime())->format('D M d h:i:s Y');
+        $now = (new \DateTime())->format('D M d h:i:s Y');
         file_put_contents($this->destination, sprintf("[%s] %s: %s\n", $now, $level, $message), FILE_APPEND);
     }
 

--- a/src/Lemon/ResponseFactory.php
+++ b/src/Lemon/ResponseFactory.php
@@ -13,7 +13,7 @@ namespace Lemon;
  * @method static \Lemon\Http\Response resolve(mixed $data)                       Returns response depending on given data
  * @method static \Lemon\Http\Response error(int $code)                           Returns response for 400-500 http status codes.
  * @method static \Lemon\Http\Response raise(int $code)                           Returns response for 400-500 http status codes.
- * @method static static handle(int $code, callable $action)                      Registers custom handler for given status code
+ * @method static static               handle(int $code, callable $action)        Registers custom handler for given status code
  *
  * @see \Lemon\Http\ResponseFactory
  */

--- a/src/Lemon/Route.php
+++ b/src/Lemon/Route.php
@@ -4,25 +4,23 @@ declare(strict_types=1);
 
 namespace Lemon;
 
-use Exception;
-
 /**
  * Lemon Router Zest
  * Provides static layer over the Lemon Router.
  *
- * @method static \Lemon\Routing\Route get(string $path, $action)                        Creates route with method get
- * @method static \Lemon\Routing\Route post(string $path, $action)                       Creates route with method post
- * @method static \Lemon\Routing\Route put(string $path, $action)                        Creates route with method put
- * @method static \Lemon\Routing\Route head(string $path, $action)                       Creates route with method head
- * @method static \Lemon\Routing\Route delete(string $path, $action)                     Creates route with method delete
- * @method static \Lemon\Routing\Route path(string $path, $action)                       Creates route with method path
- * @method static \Lemon\Routing\Route options(string $path, $action)                    Creates route with method options
- * @method static \Lemon\Routing\Route any(string $path, callable $action)               The Lemon Router.
- * @method static \Lemon\Routing\Route template(string $path, ?string $view = null)      Creates GET route directly returning view
+ * @method static \Lemon\Routing\Route      get(string $path, $action)                   Creates route with method get
+ * @method static \Lemon\Routing\Route      post(string $path, $action)                  Creates route with method post
+ * @method static \Lemon\Routing\Route      put(string $path, $action)                   Creates route with method put
+ * @method static \Lemon\Routing\Route      head(string $path, $action)                  Creates route with method head
+ * @method static \Lemon\Routing\Route      delete(string $path, $action)                Creates route with method delete
+ * @method static \Lemon\Routing\Route      path(string $path, $action)                  Creates route with method path
+ * @method static \Lemon\Routing\Route      options(string $path, $action)               Creates route with method options
+ * @method static \Lemon\Routing\Route      any(string $path, callable $action)          The Lemon Router.
+ * @method static \Lemon\Routing\Route      template(string $path, ?string $view = null) Creates GET route directly returning view
  * @method static \Lemon\Routing\Collection collection(callable $routes)                 Creates collection of routes created in given callback
  * @method static \Lemon\Routing\Collection file(string $file)                           Creates collection of routes created in given file
  * @method static \Lemon\Routing\Collection controller(string $base, string $controller) Creates collection of given controller
- * @method static \Lemon\Http\Response dispatch(Request $request)                        Finds route depending on given request.
+ * @method static \Lemon\Http\Response      dispatch(Request $request)                   Finds route depending on given request.
  * @method static \Lemon\Routing\Collection routes()                                     Returns all routes
  *
  * @see \Lemon\Routing\Router
@@ -37,6 +35,6 @@ class Route extends Zest
     public static function dispatch()
     {
         // This basically prevents calling method dispatch in zest
-        throw new Exception('Call to undefined method Route::dispatch');
+        throw new \Exception('Call to undefined method Route::dispatch');
     }
 }

--- a/src/Lemon/Routing/Exceptions/RouteException.php
+++ b/src/Lemon/Routing/Exceptions/RouteException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Routing\Exceptions;
 
-use Exception;
-
-class RouteException extends Exception
+class RouteException extends \Exception
 {
 }

--- a/src/Lemon/Routing/Route.php
+++ b/src/Lemon/Routing/Route.php
@@ -106,7 +106,7 @@ class Route
         $result = [new $action[0](), $action[1]];
 
         if (!is_callable($result)) {
-            throw new RouteException('Action '.$action[0].'::'.$action[1].'()'.' is not callable.');
+            throw new RouteException('Action '.$action[0].'::'.$action[1].'() is not callable.');
         }
 
         return $result;

--- a/src/Lemon/Session.php
+++ b/src/Lemon/Session.php
@@ -8,14 +8,14 @@ namespace Lemon;
  * Lemon Session Zest
  * Provides static layer over the Lemon Session.
  *
- * @method static void init()                                        Starts session if not started.
- * @method static \Lemon\Http\Session expireAt(int $seconds)         Sets expiration.
- * @method static \Lemon\Http\Session dontExpire()                   Removes expiration.
- * @method static string get(string $key)                            Returns value of given key.
- * @method static \Lemon\Http\Session set(string $key, mixed $value) Sets value for given key.
- * @method static bool has(string $key)                              Determins whenever key exists.
- * @method static \Lemon\Http\Sessionremove(string $key)             Removes key.
- * @method static void clear()                                       Clears session.
+ * @method static void                init()                                 Starts session if not started.
+ * @method static \Lemon\Http\Session expireAt(int $seconds)                 Sets expiration.
+ * @method static \Lemon\Http\Session dontExpire()                           Removes expiration.
+ * @method static string              get(string $key)                       Returns value of given key.
+ * @method static \Lemon\Http\Session set(string $key, mixed $value)         Sets value for given key.
+ * @method static bool                has(string $key)                       Determins whenever key exists.
+ * @method        static              \Lemon\Http\Sessionremove(string $key) Removes key.
+ * @method static void                clear()                                Clears session.
  *
  * @see \Lemon\Http\Session
  */

--- a/src/Lemon/Support/Env.php
+++ b/src/Lemon/Support/Env.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Support;
 
-use Exception;
 use Lemon\Contracts\Support\Env as EnvContract;
 use Lemon\Kernel\Application;
 
@@ -47,7 +46,7 @@ final class Env implements EnvContract
             }
             $data = explode('=', $line);
             if (2 != count($data)) {
-                throw new Exception('Env file does not contain valid data');
+                throw new \Exception('Env file does not contain valid data');
             }
             $this->data[$data[0]] = $data[1] ?: null;
         }

--- a/src/Lemon/Support/Exceptions/FilesystemException.php
+++ b/src/Lemon/Support/Exceptions/FilesystemException.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Lemon\Support\Exceptions;
 
-use Exception;
-
-class FilesystemException extends Exception
+class FilesystemException extends \Exception
 {
     public static function explainFileNotFound($file): self
     {

--- a/src/Lemon/Support/Filesystem.php
+++ b/src/Lemon/Support/Filesystem.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Support;
 
-use Exception;
 use Lemon\Support\Exceptions\FilesystemException;
 
 class Filesystem
@@ -124,7 +123,7 @@ class Filesystem
     public static function join(string ...$paths): string
     {
         if (count($paths) < 2) {
-            throw new Exception('Function Filesystem::join takes at least 2 arguments');
+            throw new \Exception('Function Filesystem::join takes at least 2 arguments');
         }
 
         $start = str_starts_with($paths[0], DIRECTORY_SEPARATOR) ? DIRECTORY_SEPARATOR : '';

--- a/src/Lemon/Support/Macros.php
+++ b/src/Lemon/Support/Macros.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Support;
 
-use Closure;
-use Exception;
-
 trait Macros
 {
     /**
@@ -19,11 +16,11 @@ trait Macros
     public function __call($name, $arguments)
     {
         if (!isset($this->macros[$name])) {
-            throw new Exception('Call to undefined function '.$name);
+            throw new \Exception('Call to undefined function '.$name);
         }
 
         $macro = $this->macros[$name];
-        if ($macro instanceof Closure) {
+        if ($macro instanceof \Closure) {
             $macro = $macro->bindTo($this);
         }
 

--- a/src/Lemon/Support/Pipe.php
+++ b/src/Lemon/Support/Pipe.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Support;
 
-use Exception;
-
 class Pipe
 {
     private array $args = [];
@@ -18,7 +16,7 @@ class Pipe
     public function __call($name, $arguments): static
     {
         if ('>>>=' !== $name) { // haha
-            throw new Exception('Call to undefined method '.static::class.'::'.$name.'()');
+            throw new \Exception('Call to undefined method '.static::class.'::'.$name.'()');
         }
 
         return $this->then(...$arguments);

--- a/src/Lemon/Support/Properties/Properties.php
+++ b/src/Lemon/Support/Properties/Properties.php
@@ -4,21 +4,18 @@ declare(strict_types=1);
 
 namespace Lemon\Support\Properties;
 
-use Exception;
-use ReflectionClass;
-
 trait Properties
 {
     public function __get(string $name): mixed
     {
         if (in_array($name, array_keys(get_class_vars(static::class)))) {
-            $class = new ReflectionClass(static::class);
+            $class = new \ReflectionClass(static::class);
             $property = $class->getProperty($name);
             if ($property->getAttributes(Read::class)) {
                 return $this->{$name};
             }
         }
 
-        throw new Exception('Undefined property '.$name);
+        throw new \Exception('Undefined property '.$name);
     }
 }

--- a/src/Lemon/Support/Properties/Read.php
+++ b/src/Lemon/Support/Properties/Read.php
@@ -6,7 +6,7 @@ namespace Lemon\Support\Properties;
 
 use Attribute;
 
-#[Attribute()]
+#[\Attribute()]
 class Read
 {
 }

--- a/src/Lemon/Support/Types/Arr.php
+++ b/src/Lemon/Support/Types/Arr.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Support\Types;
 
-use Generator;
-
 /**
  * Here is regex for replacing Arr::hasKey to array_key_exists
  * :%s/Arr::hasKey(\(.\+\),\s*\([^)]\+\))/array_key_exists(\2, \1).
@@ -35,7 +33,7 @@ class Arr
     /**
      * Lazy implementation of range procedure.
      */
-    public static function range(int $from, int $to): Generator
+    public static function range(int $from, int $to): \Generator
     {
         $step = $from < $to ? 1 : -1;
 

--- a/src/Lemon/Support/Types/Nothing.php
+++ b/src/Lemon/Support/Types/Nothing.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Support\Types;
 
-use Exception;
-
 class Nothing extends Maybe
 {
     public function unwrap(mixed $default = null): mixed
@@ -15,7 +13,7 @@ class Nothing extends Maybe
 
     public function expect(string $error): mixed
     {
-        throw new Exception($error);
+        throw new \Exception($error);
     }
 
     public function then(callable $action): static

--- a/src/Lemon/Support/Types/Stack.php
+++ b/src/Lemon/Support/Types/Stack.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Support\Types;
 
-use InvalidArgumentException;
-
 class Stack
 {
     private array $storage = [];
@@ -29,7 +27,7 @@ class Stack
     public function push(mixed $value): static
     {
         if (!Type::is($this->type, $value)) {
-            throw new InvalidArgumentException('Argument 1 of function '.static::class.'::push() must be type '.$this->type.' '.gettype($value).' given');
+            throw new \InvalidArgumentException('Argument 1 of function '.static::class.'::push() must be type '.$this->type.' '.gettype($value).' given');
         }
         $this->storage[] = $value;
 

--- a/src/Lemon/Template.php
+++ b/src/Lemon/Template.php
@@ -8,10 +8,10 @@ namespace Lemon;
  * Lemon Template Zest
  * Provides static layer over the Lemon Templating.
  *
- * @method static \Lemon\Templating\Template make(string $name, array $data = []) Manages and generates templates.
- * @method static string|false getRawPath(string $name)                           Returns path of raw template.
- * @method static string getCompiledPath(string $name)                            Returns path of compiled template.
- * @method static void compile(string $raw_path, string $compiled_path)           Compiles template and caches it.
+ * @method static \Lemon\Templating\Template make(string $name, array $data = [])             Manages and generates templates.
+ * @method static string|false               getRawPath(string $name)                         Returns path of raw template.
+ * @method static string                     getCompiledPath(string $name)                    Returns path of compiled template.
+ * @method static void                       compile(string $raw_path, string $compiled_path) Compiles template and caches it.
  *
  * @see \Lemon\Templating\Factory
  */

--- a/src/Lemon/Templating/Exceptions/CompilerException.php
+++ b/src/Lemon/Templating/Exceptions/CompilerException.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Lemon\Templating\Exceptions;
 
-use Exception;
-
-class CompilerException extends Exception
+class CompilerException extends \Exception
 {
     public function __construct(string $message, int $line = null)
     {

--- a/src/Lemon/Templating/Exceptions/SyntaxException.php
+++ b/src/Lemon/Templating/Exceptions/SyntaxException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Templating\Exceptions;
 
-use Exception;
-
-class SyntaxException extends Exception
+class SyntaxException extends \Exception
 {
 }

--- a/src/Lemon/Templating/Exceptions/TemplateException.php
+++ b/src/Lemon/Templating/Exceptions/TemplateException.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace Lemon\Templating\Exceptions;
 
-use ErrorException;
-use Throwable;
-
-class TemplateException extends ErrorException
+class TemplateException extends \ErrorException
 {
-    public static function from(Throwable $original, string $source): self
+    public static function from(\Throwable $original, string $source): self
     {
         return new self($original->getMessage(), $original->getCode(), 1, $source, $original->getLine());
     }

--- a/src/Lemon/Templating/Factory.php
+++ b/src/Lemon/Templating/Factory.php
@@ -10,7 +10,6 @@ use Lemon\Contracts\Templating\Factory as FactoryInterface;
 use Lemon\Kernel\Application;
 use Lemon\Support\Filesystem as FS;
 use Lemon\Templating\Exceptions\TemplateException;
-use Throwable;
 
 /**
  * Manages and generates templates.
@@ -97,7 +96,7 @@ final class Factory implements FactoryInterface
 
         try {
             $compiled = $this->compiler->compile(file_get_contents($raw_path));
-        } catch (Throwable $throwable) {
+        } catch (\Throwable $throwable) {
             throw TemplateException::from($throwable, $raw_path);
         }
 

--- a/src/Lemon/Templating/Juice/Lexer.php
+++ b/src/Lemon/Templating/Juice/Lexer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Templating\Juice;
 
-use ArrayIterator;
 use Lemon\Support\Regex;
 use Lemon\Templating\Exceptions\SyntaxException;
 
@@ -31,7 +30,7 @@ final class Lexer
     private function tokenize(string $template, array $lex): array
     {
         $result = [];
-        $lex = new ArrayIterator($lex);
+        $lex = new \ArrayIterator($lex);
         foreach ($lex as [$word, $offset]) {
             if (!$word) {
                 continue;

--- a/src/Lemon/Templating/Juice/Parser.php
+++ b/src/Lemon/Templating/Juice/Parser.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Templating\Juice;
 
-use ArrayIterator;
 use Lemon\Support\Types\Arr;
 use Lemon\Templating\Exceptions\CompilerException;
 use Lemon\Templating\Juice\Compilers\DirectiveCompiler;
@@ -32,16 +31,16 @@ final class Parser
     /**
      * Stream of all tokens.
      *
-     * @var ArrayIterator<Token>
+     * @var \ArrayIterator<Token>
      */
-    private ArrayIterator $tokens;
+    private \ArrayIterator $tokens;
 
     public function __construct(
         array $tokens,
         private OutputCompiler $output,
         private DirectiveCompiler $directives
     ) {
-        $this->tokens = new ArrayIterator($tokens);
+        $this->tokens = new \ArrayIterator($tokens);
     }
 
     /**

--- a/src/Lemon/Templating/Template.php
+++ b/src/Lemon/Templating/Template.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Lemon\Templating;
 
 use Lemon\Templating\Exceptions\TemplateException;
-use Throwable;
 
 /**
  * Represents compiled template.
@@ -32,7 +31,7 @@ final class Template
 
         try {
             require $this->compiled_path;
-        } catch (Throwable $e) {
+        } catch (\Throwable $e) {
             ob_get_clean();
 
             throw TemplateException::from($e, $this->raw_path);

--- a/src/Lemon/Terminal.php
+++ b/src/Lemon/Terminal.php
@@ -4,16 +4,14 @@ declare(strict_types=1);
 
 namespace Lemon;
 
-use Exception;
-
 /**
  * Lemon Terminal Zest
  * Provides static layer over the Lemon Terminal.
  *
  * @method static \Lemon\Terminal\Command command(string $signature, Closure $action, string $description = '') Creates new command
- * @method static void out(mixed $content)                                                                      Outputs given content
- * @method static string ask(mixed $prompt)                                                                     Asks in terminal
- * @method static void run(array $arguments)                                                                    Runs CLI
+ * @method static void                    out(mixed $content)                                                   Outputs given content
+ * @method static string                  ask(mixed $prompt)                                                    Asks in terminal
+ * @method static void                    run(array $arguments)                                                 Runs CLI
  *
  * @see \Lemon\Terminal\Terminal
  */
@@ -26,6 +24,6 @@ class Terminal extends Zest
 
     public static function run(): void
     {
-        throw new Exception('Call to undefined method Terminal::run()');
+        throw new \Exception('Call to undefined method Terminal::run()');
     }
 }

--- a/src/Lemon/Terminal/Commands/Command.php
+++ b/src/Lemon/Terminal/Commands/Command.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Terminal\Commands;
 
-use Closure;
 use Lemon\Terminal\Exceptions\CommandException;
 
 class Command
@@ -15,7 +14,7 @@ class Command
 
     public function __construct(
         public string $signature,
-        public readonly Closure $action, // Maybe bad idea?
+        public readonly \Closure $action, // Maybe bad idea?
         public readonly string $description = ''
     ) {
         // maybe bad idea

--- a/src/Lemon/Terminal/Exceptions/CommandException.php
+++ b/src/Lemon/Terminal/Exceptions/CommandException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Terminal\Exceptions;
 
-use Exception;
-
-class CommandException extends Exception
+class CommandException extends \Exception
 {
 }

--- a/src/Lemon/Terminal/Exceptions/HtmlException.php
+++ b/src/Lemon/Terminal/Exceptions/HtmlException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Terminal\Exceptions;
 
-use Exception;
-
-class HtmlException extends Exception
+class HtmlException extends \Exception
 {
 }

--- a/src/Lemon/Terminal/Exceptions/IOException.php
+++ b/src/Lemon/Terminal/Exceptions/IOException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Terminal\Exceptions;
 
-use Exception;
-
-class IOException extends Exception
+class IOException extends \Exception
 {
 }

--- a/src/Lemon/Terminal/IO/Html/Components.php
+++ b/src/Lemon/Terminal/IO/Html/Components.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Terminal\IO\Html;
 
-use DOMNode;
-use DOMText;
 use Lemon\Terminal\Exceptions\HtmlException;
 
 class Components
@@ -17,7 +15,7 @@ class Components
         $this->styles = new Styles();
     }
 
-    public function parse(DOMNode $element): string
+    public function parse(\DOMNode $element): string
     {
         $result = '';
         foreach ($element->childNodes as $child) {
@@ -28,9 +26,9 @@ class Components
         return $result."\033[0m";
     }
 
-    public function parseElement(DOMNode $element): string
+    public function parseElement(\DOMNode $element): string
     {
-        if ($element instanceof DOMText) {
+        if ($element instanceof \DOMText) {
             return self::removeWhitespace($element);
         }
 
@@ -44,12 +42,12 @@ class Components
         throw new HtmlException('Html tag '.$name.' is not supported');
     }
 
-    public function parseDiv(DOMNode $element): string
+    public function parseDiv(\DOMNode $element): string
     {
         return $this->parse($element);
     }
 
-    public function parseH1(DOMNode $element): string
+    public function parseH1(\DOMNode $element): string
     {
         $content = $this->parse($element);
         $line = '+'.str_repeat('-', self::lenght($content) + 2).'+';
@@ -62,17 +60,17 @@ class Components
         return str_repeat('-', (int) exec('tput cols')); // TODO size
     }
 
-    public function parseB(DOMNode $node): string
+    public function parseB(\DOMNode $node): string
     {
         return "\033[1m".$this->parse($node);
     }
 
-    public function parseI(DOMNode $node): string
+    public function parseI(\DOMNode $node): string
     {
         return "\033[3m".$this->parse($node);
     }
 
-    public function parseU(DOMNode $node): string
+    public function parseU(\DOMNode $node): string
     {
         return "\033[4m".$this->parse($node);
     }
@@ -82,7 +80,7 @@ class Components
         return PHP_EOL;
     }
 
-    public function parseP(DOMNode $node): string
+    public function parseP(\DOMNode $node): string
     {
         return $this->parse($node).PHP_EOL;
     }
@@ -92,7 +90,7 @@ class Components
         return strlen(preg_replace("/\033\\[[0-9]+m/", '', $target));
     }
 
-    public static function removeWhitespace(DOMText $element): string
+    public static function removeWhitespace(\DOMText $element): string
     {
         $content = $element->textContent;
         if (null === $element->previousSibling) {

--- a/src/Lemon/Terminal/IO/Html/HtmlOutput.php
+++ b/src/Lemon/Terminal/IO/Html/HtmlOutput.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Terminal\IO\Html;
 
-use DOMDocument;
-use DOMNode;
-
 class HtmlOutput
 {
     private Components $components;
@@ -21,9 +18,9 @@ class HtmlOutput
         return $this->components->parse($this->getDom($content));
     }
 
-    private function getDom(string $content): DOMNode
+    private function getDom(string $content): \DOMNode
     {
-        $dom = new DOMDocument();
+        $dom = new \DOMDocument();
         $dom->loadHTML($content);
 
         return $dom->getElementsByTagName('body')[0];

--- a/src/Lemon/Terminal/IO/Html/Styles.php
+++ b/src/Lemon/Terminal/IO/Html/Styles.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Terminal\IO\Html;
 
-use DOMNode;
 use Lemon\Terminal\Exceptions\HtmlException;
 
 class Styles
@@ -31,7 +30,7 @@ class Styles
         'bg-white' => ['%e47m', '', ''],
     ];
 
-    public function getStyle(DOMNode $node): array
+    public function getStyle(\DOMNode $node): array
     {
         if (!isset($node->attributes['class'])) {
             return ['', '', ''];

--- a/src/Lemon/Terminal/Terminal.php
+++ b/src/Lemon/Terminal/Terminal.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Terminal;
 
-use Closure;
 use Lemon\Contracts\Terminal\Terminal as TerminalContract;
 use Lemon\Kernel\Application;
 use Lemon\Terminal\Commands\Command;
@@ -27,7 +26,7 @@ class Terminal implements TerminalContract
     /**
      * Creates new command.
      */
-    public function command(string $signature, Closure $action, string $description = ''): Command
+    public function command(string $signature, \Closure $action, string $description = ''): Command
     {
         $command = new Command($signature, $action, $description);
         $this->commands->add($command);

--- a/src/Lemon/Testing/Mock.php
+++ b/src/Lemon/Testing/Mock.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Testing;
 
-use Closure;
-use Mockery;
 use Mockery\MockInterface;
 
 class Mock
@@ -15,7 +13,7 @@ class Mock
     public function __construct(string $class)
     {
         // @phpstan-ignore-next-line
-        $this->mock = Mockery::mock($class);
+        $this->mock = \Mockery::mock($class);
     }
 
     public function expect(callable ...$methods): MockInterface
@@ -23,7 +21,7 @@ class Mock
         foreach ($methods as $method => $action) {
             // @phpstan-ignore-next-line
             $this->mock->shouldReceive($method)
-                ->andReturnUsing(Closure::fromCallable($action)->bindTo($this->mock))
+                ->andReturnUsing(\Closure::fromCallable($action)->bindTo($this->mock))
             ;
         }
 

--- a/src/Lemon/Validation/Exceptions/ValidatorException.php
+++ b/src/Lemon/Validation/Exceptions/ValidatorException.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Validation;
 
-use Exception;
-
-class ValidatorException extends Exception
+class ValidatorException extends \Exception
 {
 }

--- a/src/Lemon/Validator.php
+++ b/src/Lemon/Validator.php
@@ -8,9 +8,9 @@ namespace Lemon;
  * Lemon Validator Zest
  * Provides static layer over the Lemon Validator.
  *
- * @method static \Lemon\Validation\Rules rules()            Returns all rules.
- * @method static bool validate(array $data, array $ruleset) Determins whenever given data meets given rules.
- * @method static array resolveRules(array|string $rules)    Converts rules into same array.
+ * @method static \Lemon\Validation\Rules rules()                               Returns all rules.
+ * @method static bool                    validate(array $data, array $ruleset) Determins whenever given data meets given rules.
+ * @method static array                   resolveRules(array|string $rules)     Converts rules into same array.
  *
  * @see \Lemon\Validation\Validator
  */

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Config;
 
-use DateInterval;
 use Lemon\Cache\Cache as LemonCache;
 use Lemon\Cache\Exceptions\InvalidArgumentException;
 use Lemon\Config\Config;
@@ -29,6 +28,7 @@ class FakeCache extends LemonCache
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class FakeCacheTest extends TestCase
@@ -41,7 +41,7 @@ class FakeCacheTest extends TestCase
         $this->assertSame(['foo' => ['value' => 'bar', 'expires_at' => null]], $cache->data());
         $cache->set('foo', 'baz', 10);
         $this->assertSame(['foo' => ['value' => 'baz', 'expires_at' => $time + 10]], $cache->data());
-        $cache->set('foo', 'klobna', new DateInterval('PT12S'));
+        $cache->set('foo', 'klobna', new \DateInterval('PT12S'));
         $this->assertSame(['foo' => ['value' => 'klobna', 'expires_at' => $time + 12]], $cache->data());
         $this->expectException(InvalidArgumentException::class);
         $cache->set('klobna', 'rizek', -5);
@@ -131,7 +131,7 @@ class FakeCacheTest extends TestCase
         $cache->setMultiple([
             'majkel' => 'klobasnik',
             'fid' => 'parek',
-        ], new DateInterval('PT2S'));
+        ], new \DateInterval('PT2S'));
 
         $this->assertSame([
             'majkel' => ['value' => 'klobasnik', 'expires_at' => $time + 2],
@@ -198,6 +198,7 @@ class FakeCacheTest extends TestCase
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class CacheTest extends TestCase

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -12,6 +12,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ConfigTest extends TestCase

--- a/tests/Database/DatabaseTest.php
+++ b/tests/Database/DatabaseTest.php
@@ -14,6 +14,7 @@ use Lemon\Zest;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class DatabaseTest extends TestCase

--- a/tests/Database/Drivers/SqliteTest.php
+++ b/tests/Database/Drivers/SqliteTest.php
@@ -13,6 +13,7 @@ use Lemon\Zest;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class SqliteTest extends TestCase

--- a/tests/Debug/ConsultantTest.php
+++ b/tests/Debug/ConsultantTest.php
@@ -10,6 +10,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ConsultantTest extends TestCase

--- a/tests/Debug/DumperTest.php
+++ b/tests/Debug/DumperTest.php
@@ -11,6 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class DumperTest extends TestCase

--- a/tests/Debug/StyleTest.php
+++ b/tests/Debug/StyleTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class StyleTest extends TestCase

--- a/tests/Events/DispatcherTest.php
+++ b/tests/Events/DispatcherTest.php
@@ -10,6 +10,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class DispatcherTest extends TestCase

--- a/tests/Http/Middlewares/CorsTest.php
+++ b/tests/Http/Middlewares/CorsTest.php
@@ -14,6 +14,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class CorsTest extends TestCase

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Http;
 
-use Exception;
 use Lemon\Http\File;
 use Lemon\Http\Request;
 use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class RequestTest extends TestCase
@@ -64,7 +64,7 @@ class RequestTest extends TestCase
         $r = new Request('/', '', 'GET', ['Content-Type' => 'application/json'], '{"foo":"bar"}', [], []);
         $this->assertThrowable(function () use ($r) {
             $r->validate(['foo' => 'max:3']);
-        }, Exception::class);
+        }, \Exception::class);
     }
 
     public function testCookies()

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Http;
 
-use DateTime;
-use DateTimeInterface;
 use Lemon\Http\Responses\HtmlResponse;
 use Lemon\Http\Responses\JsonResponse;
 use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ResponseTest extends TestCase
 {
     /**
      * @runInSeparateProcess
+     *
      * @preserveGlobalState disabled
      *
      * @see https://github.com/sebastianbergmann/phpunit/issues/720#issuecomment-10421092
@@ -65,7 +65,7 @@ class ResponseTest extends TestCase
         $r = new HtmlResponse('foo');
         $time = time();
         $r->cookie('foo', 'bar', $time + 60);
-        $expires = (new DateTime())->setTimestamp($time + 60)->format(DateTimeInterface::RFC7231);
+        $expires = (new \DateTime())->setTimestamp($time + 60)->format(\DateTimeInterface::RFC7231);
         $this->assertSame("HTTP/1.1 200 OK\r\nSet-Cookie: foo=bar Expires={$expires}\r\nContent-Type: text/html\r\n\r\nfoo", (string) $r);
 
         $r = new HtmlResponse('foo', 500, ['Foo' => 'Bar']);

--- a/tests/Kernel/ContainerTest.php
+++ b/tests/Kernel/ContainerTest.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ContainerTest extends TestCase

--- a/tests/Kernel/LifecycleTest.php
+++ b/tests/Kernel/LifecycleTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ApplicationTest extends TestCase

--- a/tests/Kernel/ZestTest.php
+++ b/tests/Kernel/ZestTest.php
@@ -13,6 +13,7 @@ use Lemon\Zest;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ZestTest extends TestCase

--- a/tests/Logging/LoggerTest.php
+++ b/tests/Logging/LoggerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Logging;
 
-use DateTime;
 use Lemon\Config\Config;
 use Lemon\Kernel\Application;
 use Lemon\Logging\Logger;
@@ -15,6 +14,7 @@ use Psr\Log\LogLevel;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class LoggerTest extends TestCase
@@ -43,7 +43,7 @@ class LoggerTest extends TestCase
         $log->log(LogLevel::INFO, '{what} se hrouti', ['what' => 'festival']);
         $log->log(LogLevel::ALERT, '{what} protekaji', ['what' => 'zachody']);
         $log->log(LogLevel::EMERGENCY, 'on proste nema svoje kafe');
-        $now = (new DateTime())->format('D M d h:i:s Y');
+        $now = (new \DateTime())->format('D M d h:i:s Y');
         $this->assertStringEqualsFile(Filesystem::join(__DIR__, 'storage', 'logs', 'lemon.log'), sprintf(<<<'LOG'
         [%s] INFO: festival se hrouti
         [%s] ALERT: zachody protekaji

--- a/tests/Protection/CsrfTest.php
+++ b/tests/Protection/CsrfTest.php
@@ -17,6 +17,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class CsrfTest extends TestCase

--- a/tests/Routing/CollectionTest.php
+++ b/tests/Routing/CollectionTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class CollectionTest extends TestCase

--- a/tests/Routing/MiddlewareTest.php
+++ b/tests/Routing/MiddlewareTest.php
@@ -23,12 +23,14 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class MiddlewareTest extends TestCase
 {
     /**
      * @runInSeparateProcess
+     *
      * @preserveGlobalState disabled
      */
     public function testCollection()

--- a/tests/Routing/RouteTest.php
+++ b/tests/Routing/RouteTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Routing;
 
-use Closure;
 use Lemon\Routing\Exceptions\RouteException;
 use Lemon\Routing\Route;
 use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class RouteTest extends TestCase
 {
     public function testAction()
     {
-        $closure = Closure::fromCallable(fn () => 'foo');
+        $closure = \Closure::fromCallable(fn () => 'foo');
         $route = new Route('/', ['get' => $closure]);
 
         $this->assertSame($closure, $route->action('get'));

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -17,10 +17,10 @@ use Lemon\Support\Filesystem;
 use Lemon\Templating\Factory;
 use Lemon\Templating\Template;
 use Lemon\Tests\TestCase;
-use ReflectionClass;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class RouterTest extends TestCase
@@ -135,7 +135,7 @@ class RouterTest extends TestCase
         $this->assertThat($r->dispatch($this->emulate('/foo/bar', 'GET')), $this->equalTo(new HtmlResponse('bar')));
         $this->assertThat($r->dispatch($this->emulate('/foo/bar/', 'GET')), $this->equalTo(new HtmlResponse('bar')));
 
-        $path = Filesystem::join(dirname((new ReflectionClass(ResponseFactory::class))->getFileName()), 'templates', 'error.phtml');
+        $path = Filesystem::join(dirname((new \ReflectionClass(ResponseFactory::class))->getFileName()), 'templates', 'error.phtml');
         $this->assertThat($r->dispatch($this->emulate('foo', 'GET')), $this->equalTo(new TemplateResponse(new Template($path, $path, ['code' => 404]), 404)));
         $this->assertThat($r->dispatch($this->emulate('/', 'POST')), $this->equalTo(new TemplateResponse(new Template($path, $path, ['code' => 400]), 400)));
     }

--- a/tests/Support/CaseConverterTest.php
+++ b/tests/Support/CaseConverterTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class CaseConverterTest extends TestCase

--- a/tests/Support/EnvTest.php
+++ b/tests/Support/EnvTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Support;
 
-use Exception;
 use Lemon\Kernel\Application;
 use Lemon\Support\Env;
 use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class EnvTest extends TestCase
@@ -35,7 +35,7 @@ class EnvTest extends TestCase
 
         $this->assertThrowable(function () {
             $env = $this->getEnv("FOO=bar\r\nparek");
-        }, Exception::class);
+        }, \Exception::class);
 
         $env = $this->getEnv("FOO=bar\r\nparek=\n");
 

--- a/tests/Support/FilesystemTest.php
+++ b/tests/Support/FilesystemTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Support;
 
-use Exception;
 use Lemon\Support\Exceptions\FilesystemException;
 use Lemon\Support\Filesystem;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class FilesystemTest extends TestCase
@@ -116,7 +116,7 @@ class FilesystemTest extends TestCase
         $this->assertSame('foo'.$s.'klobna.php', Filesystem::join('foo'.$s.$s.$s, 'klobna.php'));
         $this->assertSame($s.'foo'.$s.'klobna.php', Filesystem::join($s.'foo', 'klobna.php'));
         $this->assertSame('foo'.$s.'klobna.php', Filesystem::join('foo', 'klobna.php'.$s.$s.$s));
-        $this->expectException(Exception::class);
+        $this->expectException(\Exception::class);
         Filesystem::join('parek');
         Filesystem::join();
     }

--- a/tests/Support/Helpers.php
+++ b/tests/Support/Helpers.php
@@ -8,6 +8,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class Helpers extends TestCase

--- a/tests/Support/HelpersTest.php
+++ b/tests/Support/HelpersTest.php
@@ -8,6 +8,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class HelpersTest extends TestCase

--- a/tests/Support/MacrosTest.php
+++ b/tests/Support/MacrosTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class MacrosTest extends TestCase

--- a/tests/Support/PipeTest.php
+++ b/tests/Support/PipeTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class PipeTest extends TestCase

--- a/tests/Support/Properties/PropertiesTest.php
+++ b/tests/Support/Properties/PropertiesTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Support\Properties;
 
-use Exception;
 use Lemon\Support\Properties\Properties;
 use Lemon\Support\Properties\Read;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +23,7 @@ class Foo
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class PropertiesTest extends TestCase
@@ -33,7 +33,7 @@ class PropertiesTest extends TestCase
         $f = new Foo();
         $this->assertSame('parek', $f->bar);
         $this->assertNull($f->baz);
-        $this->expectException(Exception::class);
+        $this->expectException(\Exception::class);
         $f->foo;
         $f->klobna;
     }

--- a/tests/Support/RegexTest.php
+++ b/tests/Support/RegexTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class RegexTest extends TestCase

--- a/tests/Support/Types/ArrTest.php
+++ b/tests/Support/Types/ArrTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ArrTest extends TestCase

--- a/tests/Support/Types/MaybeTest.php
+++ b/tests/Support/Types/MaybeTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class MaybeTest extends TestCase

--- a/tests/Support/Types/StackTest.php
+++ b/tests/Support/Types/StackTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Support\Types;
 
-use InvalidArgumentException;
 use Lemon\Support\Types\Stack;
 use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class StackTest extends TestCase
@@ -24,7 +24,7 @@ class StackTest extends TestCase
 
         $stack = Stack::withType('integer');
         $stack->push(1);
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
         $stack->push('foo');
     }
 

--- a/tests/Support/Types/TypeTest.php
+++ b/tests/Support/Types/TypeTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class TypeTest extends TestCase

--- a/tests/Templating/FactoryTest.php
+++ b/tests/Templating/FactoryTest.php
@@ -17,6 +17,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class FactoryTest extends TestCase

--- a/tests/Templating/Juice/CompilerTest.php
+++ b/tests/Templating/Juice/CompilerTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class CompilerTest extends TestCase

--- a/tests/Templating/Juice/Compilers/DirectiveCompilerTest.php
+++ b/tests/Templating/Juice/Compilers/DirectiveCompilerTest.php
@@ -30,6 +30,7 @@ class BarDirective
 // TODO switch compilers test to directivecompiler like youknow
 /**
  * @internal
+ *
  * @coversNothing
  */
 class DirectiveCompilerTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/CaseDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/CaseDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class CaseDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/CsrfDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/CsrfDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class CsrfDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/ElseDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/ElseDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ElseDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/ElseIfDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/ElseIfDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ElseIfDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/ForDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/ForDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ForDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/ForeachDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/ForeachDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ForeachDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/IfDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/IfDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class IfDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/IncludeDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/IncludeDirectiveTest.php
@@ -15,6 +15,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class IncludeDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/Layout/BlockTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/Layout/BlockTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class BlockTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/Layout/ExtendsTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/Layout/ExtendsTest.php
@@ -15,6 +15,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ExtendsDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/Layout/LayoutTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/Layout/LayoutTest.php
@@ -10,6 +10,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class LayoutTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/Layout/YieldTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/Layout/YieldTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class YieldTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/SwitchDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/SwitchDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class SwitchDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/UnlessDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/UnlessDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class UnlessDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/Directives/WhileDirectiveTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/WhileDirectiveTest.php
@@ -11,6 +11,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class WhileDirectiveTest extends TestCase

--- a/tests/Templating/Juice/Compilers/OutputCompilerTest.php
+++ b/tests/Templating/Juice/Compilers/OutputCompilerTest.php
@@ -10,6 +10,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class OutputCompilerTest extends TestCase

--- a/tests/Templating/Juice/ContextTest.php
+++ b/tests/Templating/Juice/ContextTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ContextTest extends TestCase

--- a/tests/Templating/Juice/LexerTest.php
+++ b/tests/Templating/Juice/LexerTest.php
@@ -13,6 +13,7 @@ use PHPUnit\Framework\TestCase;
  * Theese tests are testing lexer along with default syntax.
  *
  * @internal
+ *
  * @coversNothing
  */
 class LexerTest extends TestCase

--- a/tests/Templating/Juice/ParserTest.php
+++ b/tests/Templating/Juice/ParserTest.php
@@ -13,6 +13,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ParserTest extends TestCase

--- a/tests/Templating/TemplateTest.php
+++ b/tests/Templating/TemplateTest.php
@@ -10,6 +10,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class TemplateTest extends TestCase

--- a/tests/Terminal/Commands/CommandTest.php
+++ b/tests/Terminal/Commands/CommandTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class CommandTest extends TestCase

--- a/tests/Terminal/Commands/DispatcherTest.php
+++ b/tests/Terminal/Commands/DispatcherTest.php
@@ -10,6 +10,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class DispatcherTest extends TestCase

--- a/tests/Terminal/IO/Html/ComponentsTest.php
+++ b/tests/Terminal/IO/Html/ComponentsTest.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Terminal\IO\Html;
 
-use DOMDocument;
-use DOMNode;
 use Lemon\Terminal\IO\Html\Components;
 use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ComponentsTest extends TestCase
@@ -74,7 +73,7 @@ class ComponentsTest extends TestCase
     public function testParsing()
     {
         $components = new Components();
-        $dom = new DOMDocument();
+        $dom = new \DOMDocument();
         $dom->loadHTML(<<<'HTML'
         <h1>Something <b>cool</b></h1>
         <div class="bg-yellow">
@@ -99,9 +98,9 @@ class ComponentsTest extends TestCase
         $this->assertSame(5, Components::lenght('parek'));
     }
 
-    private function getElement(string $el): DOMNode
+    private function getElement(string $el): \DOMNode
     {
-        $dom = new DOMDocument();
+        $dom = new \DOMDocument();
         $dom->loadHTML($el);
 
         return $dom->getElementsByTagName('body')[0]->firstChild;

--- a/tests/Terminal/IO/Html/HtmlOutputTest.php
+++ b/tests/Terminal/IO/Html/HtmlOutputTest.php
@@ -9,6 +9,7 @@ use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class HtmlOutputTest extends TestCase

--- a/tests/Terminal/IO/Html/StylesTest.php
+++ b/tests/Terminal/IO/Html/StylesTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Terminal\IO\Html;
 
-use DOMDocument;
 use Lemon\Terminal\IO\Html\Styles;
 use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class StylesTest extends TestCase
@@ -17,7 +17,7 @@ class StylesTest extends TestCase
     public function testGetStyle()
     {
         $s = new Styles();
-        $dom = new DOMDocument();
+        $dom = new \DOMDocument();
         $dom->loadHTML('<div class="text-white bg-yellow"></div>');
         $node = $dom->getElementsByTagName('div')[0];
         $this->assertSame([

--- a/tests/Terminal/IO/OutputTest.php
+++ b/tests/Terminal/IO/OutputTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Terminal\IO;
 
-use Exception;
 use Lemon\Templating\Template;
 use Lemon\Terminal\IO\Output;
 use Lemon\Tests\TestCase;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class OutputTest extends TestCase
@@ -24,7 +24,7 @@ class OutputTest extends TestCase
         $path = __DIR__.DIRECTORY_SEPARATOR.'templates'.DIRECTORY_SEPARATOR.'foo.phtml';
         $this->assertSame("\033[33mnevim\033[33m\033[0m\033[0m", $output->out(new Template($path, $path, ['foo' => 'nevim'])));
 
-        $this->expectException(Exception::class);
+        $this->expectException(\Exception::class);
         $output->out($output);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Lemon\Tests;
 
 use PHPUnit\Framework\TestCase as FrameworkTestCase;
-use Throwable;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class TestCase extends FrameworkTestCase
@@ -19,7 +19,7 @@ class TestCase extends FrameworkTestCase
 
         try {
             $action(...$args);
-        } catch (Throwable $actual) {
+        } catch (\Throwable $actual) {
             if ($actual instanceof $expected) {
                 $thrown = true;
             }

--- a/tests/Testing/TestCase.php
+++ b/tests/Testing/TestCase.php
@@ -12,19 +12,18 @@ use Lemon\Http\Responses\TemplateResponse;
 use Lemon\Kernel\Application;
 use Lemon\Templating\Template;
 use Lemon\Testing\TestCase as BaseTestCase;
-use Mockery;
 
 abstract class TestCase extends BaseTestCase
 {
     public function createApplication(): Application
     {
         $app = new Application(__DIR__);
-        $templates = Mockery::mock(Factory::class);
+        $templates = \Mockery::mock(Factory::class);
         $templates->allows()->getRawPath('foo.bar')->andReturns('foo/bar.juice');
         $app->add(get_class($templates), $templates);
         $app->alias(Factory::class, get_class($templates));
 
-        $routing = Mockery::mock(Router::class);
+        $routing = \Mockery::mock(Router::class);
         $routing->expects()->dispatch(Request::class)->andReturnUsing(function (Request $request) {
             if ('/' === $request->path) {
                 return (new HtmlResponse(headers: ['Location' => 'foo']))->cookie('foo', 'bar');

--- a/tests/Testing/TestCaseTest.php
+++ b/tests/Testing/TestCaseTest.php
@@ -8,6 +8,7 @@ use Lemon\Testing\TestResponse;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class TestCaseTest extends TestCase

--- a/tests/Testing/TestResponseTest.php
+++ b/tests/Testing/TestResponseTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\AssertionFailedError;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class TestResponseTest extends TestCase

--- a/tests/Validation/RulesTest.php
+++ b/tests/Validation/RulesTest.php
@@ -9,6 +9,7 @@ use Lemon\Validation\Rules;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class RulesTest extends TestCase

--- a/tests/Validation/ValidationTest.php
+++ b/tests/Validation/ValidationTest.php
@@ -9,6 +9,7 @@ use Lemon\Validation\Validator;
 
 /**
  * @internal
+ *
  * @coversNothing
  */
 class ValidationTest extends TestCase


### PR DESCRIPTION
This PR adds optional http error handlers. If handler returns nothing it will continue and send regular Response. This allow you to have route-specific handlers or handlers that just produce some side effect (e.g. logging).

Also after development I ran php cs fixer and aperently PHPCSFixer rule set contains some new rules so it changed most of the files.