### PR TITLE
Juice tags escaping

### DIFF
--- a/src/Lemon/Templating/Juice/Lexer.php
+++ b/src/Lemon/Templating/Juice/Lexer.php
@@ -73,6 +73,7 @@ final class Lexer
             } elseif (preg_match("/^{$this->syntax->comment}$/", $word)) {
                 // Do nothing
             } else {
+                $word = str_replace($this->syntax->escape, '', $word);
                 $result[] = new Token(Token::TEXT, $word, $line);
             }
         }

--- a/src/Lemon/Templating/Juice/Lexer.php
+++ b/src/Lemon/Templating/Juice/Lexer.php
@@ -73,7 +73,7 @@ final class Lexer
             } elseif (preg_match("/^{$this->syntax->comment}$/", $word)) {
                 // Do nothing
             } else {
-                $word = str_replace($this->syntax->escape, '', $word);
+                $word = preg_replace($this->syntax->escape_regex, '$2', $word);
                 $result[] = new Token(Token::TEXT, $word, $line);
             }
         }

--- a/src/Lemon/Templating/Juice/Syntax.php
+++ b/src/Lemon/Templating/Juice/Syntax.php
@@ -10,8 +10,8 @@ namespace Lemon\Templating\Juice;
  */
 final class Syntax
 {
-
     public readonly string $regex;
+    public readonly string $escape_regex;
 
     public function __construct(
         public readonly string $tag = '\{\s*([^\{!#].*?)(?:\s+?([^\s].+?[^!\}#]))?\s*\}',
@@ -22,6 +22,7 @@ final class Syntax
         public readonly string $escape = '\\'
     ) {
         $this->regex = $this->buildRegex();
+        $this->escape_regex = $this->buildEscapeRegex();
     }
 
     /**
@@ -58,5 +59,14 @@ final class Syntax
     {
         $escape = '(?<!'.preg_quote($this->escape).')';
         return "/({$escape}{$this->tag})|({$escape}{$this->echo})|({$escape}{$this->unescaped})|({$escape}{$this->comment})/";
+    }
+
+    /**
+     * Builds regular expression used for escapment.
+     */
+    private function buildEscapeRegex(): string
+    {
+        $escape = preg_quote($this->escape);
+        return "/({$escape}({$this->tag}))|({$escape}({$this->echo}))|({$escape}({$this->unescaped}))|({$escape}({$this->comment}))/";
     }
 }

--- a/src/Lemon/Templating/Juice/Syntax.php
+++ b/src/Lemon/Templating/Juice/Syntax.php
@@ -4,39 +4,24 @@ declare(strict_types=1);
 
 namespace Lemon\Templating\Juice;
 
-use Lemon\Support\Properties\Properties;
-use Lemon\Support\Properties\Read;
 
 /**
  * Stores tag syntax for Juice.
- *
- * @property string $tag
- * @property string $echo
- * @property string $unescaped
- * @property string $end
- * @property string $comment
- * @property string $regex
  */
 final class Syntax
 {
-    use Properties;
 
-    #[Read]
-    private string $regex;
+    public readonly string $regex;
 
     public function __construct(
-        #[Read]
-        private string $tag = '\{\s*([^\{!#].*?)(?:\s+?([^\s].+?[^!\}#]))?\s*\}',
-        #[Read]
-        private string $end = '(?:end|\/)(.+)',
-        #[Read]
-        private string $echo = '\{\{\s*(.+?)\s*\}\}',
-        #[Read]
-        private string $unescaped = '\{!\s*(.+?)\s*!\}',
-        #[Read]
-        private string $comment = '\{#.+?#\}',
+        public readonly string $tag = '\{\s*([^\{!#].*?)(?:\s+?([^\s].+?[^!\}#]))?\s*\}',
+        public readonly string $end = '(?:end|\/)(.+)',
+        public readonly string $echo = '\{\{\s*(.+?)\s*\}\}',
+        public readonly string $unescaped = '\{!\s*(.+?)\s*!\}',
+        public readonly string $comment = '\{#.+?#\}',
+        public readonly string $escape = '\\'
     ) {
-        $this->buildRegex();
+        $this->regex = $this->buildRegex();
     }
 
     /**
@@ -46,11 +31,12 @@ final class Syntax
     {
         // TODO tests
         return new self(
-            '@([^\(]+)(?(?=\()\((.+?)\))',
+            '\B@([^\(]+)(?(?=\()\((.+?)\))',
             'end(.+)',
             '\{\{[^-]\s*(.+?)\s*[^-]\}\}',
             '{!!\s*(.+?)\s*!!}',
-            '{{--.+?--}}'
+            '{{--.+?--}}',
+            '@'
         );
     }
 
@@ -68,8 +54,9 @@ final class Syntax
     /**
      * Builds regular expression used for lexing.
      */
-    private function buildRegex()
+    private function buildRegex(): string
     {
-        $this->regex = "/({$this->tag})|({$this->echo})|({$this->unescaped})|({$this->comment})/";
+        $escape = '(?<!'.preg_quote($this->escape).')';
+        return "/({$escape}{$this->tag})|({$escape}{$this->echo})|({$escape}{$this->unescaped})|({$escape}{$this->comment})/";
     }
 }

--- a/tests/Templating/Juice/LexerTest.php
+++ b/tests/Templating/Juice/LexerTest.php
@@ -155,4 +155,29 @@ class LexerTest extends TestCase
             HTML, 1)
         ]));
     }
+
+    public function testLexingBlade()
+    {
+        $lexer = new Lexer(Syntax::blade());
+        $tokens = $lexer->lex(<<<'HTML'
+            <h1>{{ $foo }}</h1>
+            foo@bar.baz
+            @foreach($users as $user)
+               <h2>{{ $user }} </h2>
+                {!! md($user->description) !!}
+            @endforeach
+        HTML);
+        $this->assertThat($tokens, $this->equalTo([
+            new Token(Token::TEXT, '    <h1>', 1),
+            new Token(Token::OUTPUT, '$foo', 1),
+            new Token(Token::TEXT, "</h1>\n    foo@bar.baz\n    ", 1),
+            new Token(Token::TAG, ['foreach', '$users as $user'], 3),
+            new Token(Token::TEXT, "\n       <h2>", 4),
+            new Token(Token::OUTPUT, '$user', 4),
+            new Token(Token::TEXT, " </h2>\n        ", 4),
+            new Token(Token::UNESCAPED, 'md($user->description)', 5),
+            new Token(Token::TEXT, "\n    ", 6),
+            new Token(Token::TAG_END, 'foreach', 6),
+        ]));       
+    }
 }

--- a/tests/Templating/Juice/LexerTest.php
+++ b/tests/Templating/Juice/LexerTest.php
@@ -138,4 +138,21 @@ class LexerTest extends TestCase
             new Token(Token::TAG_END, 'foreach', 5),
         ]));
     }
+
+    public function testLexingWhitespaceStatements()
+    {
+        $lexer = $this->getLexer();
+        $tokens = $lexer->lex(<<<'HTML'
+            .foo \{
+                color: red;
+            }
+        HTML);
+    $this->assertThat($tokens, $this->equalTo([
+            new Token(Token::TEXT, <<<'HTML'
+                .foo {
+                    color: red;
+                }
+            HTML, 1)
+        ]));
+    }
 }


### PR DESCRIPTION
This PR adds escaping of juice tags. This means that when you put `\` before any juice tag ({}, {{}}, {!!}, {##}) it will be rendered without \ as it is. This allows us to write css in juice.

```juice
.foo \{
   color: red
}
```

It also fixes writing `@` in blade syntax.