### PR TITLE
[Container] Fibers

### DIFF
--- a/src/Lemon/Kernel/Container.php
+++ b/src/Lemon/Kernel/Container.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lemon\Kernel;
 
+use Fiber;
 use Lemon\Kernel\Exceptions\ContainerException;
 use Lemon\Kernel\Exceptions\NotFoundException;
 use Psr\Container\ContainerInterface;
@@ -119,7 +120,9 @@ class Container implements ContainerInterface
             }
         }
 
-        return $callback(...$injected);
+        $action = new Fiber($callback);
+
+        return $action->start(...$injected) ?? $action->getReturn();
     }
 
     /**

--- a/tests/Kernel/ContainerTest.php
+++ b/tests/Kernel/ContainerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Lemon\Tests\Kernel;
 
+use Fiber;
 use Lemon\Kernel\Container;
 use Lemon\Kernel\Exceptions\NotFoundException;
 use Lemon\Tests\Kernel\Resources\IFoo;
@@ -84,5 +85,10 @@ class ContainerTest extends TestCase
         $this->assertSame(3, $container->call(function (Foo $foo, $bar, $baz = 1) {
             return $bar + $baz;
         }, ['bar' => 2]));
+
+        $this->assertSame(3, $container->call(function() {
+            Fiber::suspend(3);
+            return 4;
+        }, []));
     }
 }


### PR DESCRIPTION
This PR uses fibers when calling function via Container::call(). Instead of regular calling it creates fiber, starts it and returns either first suspension value or return value. Meaning that in e.g routing (which uses this method) if you do

```php
Route::get('/', function() {
    Fiber::suspend(template('home'));
    return 'foo';
});
```

It would return template home, instead of 'foo'.

Curently there is no actual usage, but its first step before resolving #112 which would use this instead of Exceptions as it makes more sense. But maybe its bad idea who knows 