### PR TITLE
[Router] adds AfterAction middlewares

### DIFF
--- a/src/Lemon/Http/Middlewares/Cors.php
+++ b/src/Lemon/Http/Middlewares/Cors.php
@@ -8,6 +8,7 @@ use Lemon\Config\Exceptions\ConfigException;
 use Lemon\Contracts\Config\Config;
 use Lemon\Http\Request;
 use Lemon\Http\Response;
+use Lemon\Routing\Attributes\AfterAction;
 
 /**
  * Cors.handling middleware
@@ -19,6 +20,7 @@ class Cors
 {
     private Response $response;
 
+    #[AfterAction()]
     public function handle(Config $config, Request $request, Response $response): Response
     {
         $this->response = $response;

--- a/src/Lemon/Protection/Middlwares/Csrf.php
+++ b/src/Lemon/Protection/Middlwares/Csrf.php
@@ -8,9 +8,11 @@ use Lemon\Contracts\Http\ResponseFactory;
 use Lemon\Contracts\Protection\Csrf as ProtectionCsrf;
 use Lemon\Http\Request;
 use Lemon\Http\Response;
+use Lemon\Routing\Attributes\AfterAction;
 
 class Csrf
 {
+    #[AfterAction()]
     public function handle(Request $request, ProtectionCsrf $csrf, ResponseFactory $responseFactory, Response $response)
     {
         if ('GET' != $request->method) {

--- a/src/Lemon/Routing/Attributes/AfterAction.php
+++ b/src/Lemon/Routing/Attributes/AfterAction.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemon\Routing\Attributes;
+
+/**
+ * Represents middleware action that will be called after router action
+ */
+#[\Attribute()]
+class AfterAction
+{
+
+}


### PR DESCRIPTION
This PR fixes middleware running. Currently middlewares were ran after router action and if some middleware returned response, the response was used instead of action response. This could actually lead to some problems, so now every middleware is ran before action by default. If there is middleware with `\Lemon\Routing\Attributes\AfterAction` attribute, it would be ran after action with injectable response prototype.

So if we wanted middleware that would change header it would be like this:

```php
<?php

use Lemon\Routing\Attributes\AfterAction;
use Lemon\Http\Response;

class SomeMiddleware
{
    #[AfterAction]
    public function header(Response $prototype): Response
    {
        return $prototype->header('Content-Type', 'text/plain');
    }
}
```