### PR TITLE
[Http] CookieJar

### DIFF
--- a/src/Lemon/Contracts/Http/CookieJar.php
+++ b/src/Lemon/Contracts/Http/CookieJar.php
@@ -6,7 +6,7 @@ namespace Lemon\Contracts\Http;
 
 interface CookieJar
 {
-    public function get(string $name): string;
+    public function get(string $name): ?string;
 
     public function set(string $name, string $value, int $expires = 0): static;
 

--- a/src/Lemon/Contracts/Http/CookieJar.php
+++ b/src/Lemon/Contracts/Http/CookieJar.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemon\Contracts\Http;
+
+interface CookieJar
+{
+    public function get(string $name): string;
+
+    public function set(string $name, string $value, int $expires = 0): static;
+
+    public function delete(string $name): static; 
+
+    public function has(string $name): bool;
+
+    public function cookies(): array;
+}

--- a/src/Lemon/Debug/Handling/Handler.php
+++ b/src/Lemon/Debug/Handling/Handler.php
@@ -29,9 +29,10 @@ class Handler
         }
 
         if ($this->config->get('debug.debug')) {
-            (new Reporter($problem, $this->application->get('request'), $this->application))->report();
+            $request = $this->application->has('request') ? $this->application->get('request') : null ;
+            (new Reporter($problem, $request, $this->application))->report();
         } else {
-            $this->response->error(500)->send();
+            $this->response->error(500)->send($this->application);
             $this->logger->error((string) $problem);
         }
     }

--- a/src/Lemon/Debug/Handling/Reporter.php
+++ b/src/Lemon/Debug/Handling/Reporter.php
@@ -17,7 +17,7 @@ class Reporter
 
     public function __construct(
         private \Throwable $exception,
-        private Request $request,
+        private ?Request $request,
         private Application $application
     ) {
         $this->consultant = new Consultant();
@@ -25,7 +25,7 @@ class Reporter
 
     public function report(): void
     {
-        (new TemplateResponse($this->getTemplate(), 500))->send();
+        (new TemplateResponse($this->getTemplate(), 500))->send($this->application);
     }
 
     public function getTemplate(): Template
@@ -50,7 +50,7 @@ class Reporter
             'message' => $problem->getMessage(),
             'hint' => $this->consultant->giveAdvice($problem->getMessage()),
             'trace' => $this->getTrace(),
-            'request' => $this->request->toArray(),
+            'request' => is_null($this->request) ? [] : $this->request->toArray(),
         ];
     }
 

--- a/src/Lemon/Http/CookieJar.php
+++ b/src/Lemon/Http/CookieJar.php
@@ -17,7 +17,7 @@ class CookieJar implements CookieJarContract
 
     }
 
-    public function get(string $name): string
+    public function get(string $name): ?string
     {
         return $this->request->getCookie($name);
     }
@@ -30,7 +30,10 @@ class CookieJar implements CookieJarContract
 
     public function delete(string $name): static
     {
-        $this->set_cookies[] = [$name, '', time() - 3600];
+        if (!$this->request->hasCookie($name)) {
+            return $this;
+        }
+        $this->set_cookies[] = [$name, '', -1];
         return $this;
     }
 

--- a/src/Lemon/Http/CookieJar.php
+++ b/src/Lemon/Http/CookieJar.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemon\Http;
+
+use Lemon\Contracts\Http\CookieJar as CookieJarContract;
+use Lemon\Kernel\Application;
+
+class CookieJar implements CookieJarContract
+{
+    private array $set_cookies = [];
+
+    public function __construct(
+        private Request $request,
+    ) {
+
+    }
+
+    public function get(string $name): string
+    {
+        return $this->request->getCookie($name);
+    }
+
+    public function set(string $name, string $value, int $expires = 0): static
+    {
+        $this->set_cookies[] = [$name, $value, $expires];
+        return $this;
+    }
+
+    public function delete(string $name): static
+    {
+        $this->set_cookies[] = [$name, '', time() - 3600];
+        return $this;
+    }
+
+    public function has(string $name): bool
+    {
+        return $this->request->hasCookie($name);
+    }
+
+    public function cookies(): array
+    {
+        return $this->set_cookies;
+    }
+}

--- a/src/Lemon/Http/Response.php
+++ b/src/Lemon/Http/Response.php
@@ -115,7 +115,7 @@ abstract class Response
         $body = $this->parseBody();
         $this->handleHeaders();
         $this->handleStatusCode();
-        $this->handleCookies($app->get('cookies'));
+        $this->handleCookies($app->has('cookies') ? $app->get('cookies')->cookies() : []);
         $this->handleBody($body);
 
         return $this;
@@ -220,9 +220,9 @@ abstract class Response
         echo $body;
     }
 
-    public function handleCookies(CookieJar $cookies): void
+    public function handleCookies(array $cookies): void
     {
-        foreach ([...$this->cookies, ...$cookies->cookies()] as $cookie) {
+        foreach ([...$this->cookies, ...$cookies] as $cookie) {
             setcookie(...[...$cookie, 'httponly' => false]);
         }
     }

--- a/src/Lemon/Http/Response.php
+++ b/src/Lemon/Http/Response.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Lemon\Http;
 
+use Lemon\Contracts\Http\CookieJar;
+use Lemon\Kernel\Application;
+
+
 /**
  * Represents Http Response.
  *
@@ -106,12 +110,12 @@ abstract class Response
     /**
      * Sends response data back to user.
      */
-    public function send(): static
+    public function send(Application $app): static
     {
         $body = $this->parseBody();
         $this->handleHeaders();
         $this->handleStatusCode();
-        $this->handleCookies();
+        $this->handleCookies($app->get('cookies'));
         $this->handleBody($body);
 
         return $this;
@@ -216,9 +220,9 @@ abstract class Response
         echo $body;
     }
 
-    public function handleCookies(): void
+    public function handleCookies(CookieJar $cookies): void
     {
-        foreach ($this->cookies as $cookie) {
+        foreach ([...$this->cookies, ...$cookies->cookies()] as $cookie) {
             setcookie(...[...$cookie, 'httponly' => false]);
         }
     }

--- a/src/Lemon/Kernel/Application.php
+++ b/src/Lemon/Kernel/Application.php
@@ -64,6 +64,7 @@ final class Application extends Container
         \Lemon\Validation\Validator::class => ['validation', Contracts\Validation\Validator::class],
         \Lemon\Translating\Translator::class => ['translator', Contracts\Translating\Translator::class],
         \Lemon\Highlighter\Highlighter::class => ['highlighter', Contracts\Highlighter\Highlighter::class],
+        \Lemon\Http\CookieJar::class => ['cookies', Contracts\Http\CookieJar::class],
     ];
 
     /**
@@ -191,7 +192,7 @@ final class Application extends Container
     public function boot(): void
     {
         try {
-            $this->get('routing')->dispatch($this->get(Request::class))->send();
+            $this->get('routing')->dispatch($this->get(Request::class))->send($this);
         } catch (\Exception|\Error $e) {
             $this->handle($e);
         }

--- a/src/Lemon/Protection/Middlwares/Csrf.php
+++ b/src/Lemon/Protection/Middlwares/Csrf.php
@@ -4,16 +4,14 @@ declare(strict_types=1);
 
 namespace Lemon\Protection\Middlwares;
 
+use Lemon\Contracts\Http\CookieJar;
 use Lemon\Contracts\Http\ResponseFactory;
 use Lemon\Contracts\Protection\Csrf as ProtectionCsrf;
 use Lemon\Http\Request;
-use Lemon\Http\Response;
-use Lemon\Routing\Attributes\AfterAction;
 
 class Csrf
 {
-    #[AfterAction()]
-    public function handle(Request $request, ProtectionCsrf $csrf, ResponseFactory $responseFactory, Response $response)
+    public function handle(Request $request, ProtectionCsrf $csrf, ResponseFactory $responseFactory, CookieJar $cookies)
     {
         if ('GET' != $request->method) {
             $cookie = $request->getCookie('CSRF_TOKEN');
@@ -22,6 +20,6 @@ class Csrf
             }
         }
 
-        return $response->cookie('CSRF_TOKEN', $csrf->getToken());
+        $cookies->set('CSRF_TOKEN', $csrf->getToken());
     }
 }

--- a/tests/Http/CookieJarTest.php
+++ b/tests/Http/CookieJarTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemon\Tests\Http;
+
+use Lemon\Http\CookieJar;
+use Lemon\Http\Request;
+use Lemon\Tests\TestCase;
+
+class CookieJarTest extends TestCase
+{
+    public function getJar(array $cookies = []): CookieJar
+    {
+        return new CookieJar(new Request('', '', '', [], '', $cookies, [], ''));
+    }
+
+    public function testGet()
+    {
+        $jar = $this->getJar(['foo' => 'bar']);
+        $this->assertSame('bar', $jar->get('foo'));
+        $this->assertNull($jar->get('parek'));
+    }
+
+    public function testSet()
+    {
+        $jar = $this->getJar();
+        $jar->set('foo', 'bar');
+        $jar->set('bar', 'baz', 3600);
+
+        $this->assertSame([['foo', 'bar', 0], ['bar', 'baz', 3600]], $jar->cookies());
+    }
+
+    public function getDelete()
+    {
+        $jar = $this->getJar(['foo' => 'bar']);
+        $jar->delete('foo');
+        $this->assertSame([['foo', '', -1]], $jar->cookies());
+        $jar->delete('bar');
+        $this->assertSame([['foo', '', -1]], $jar->cookies());
+    }
+
+    public function testHas()
+    {
+        $jar = $this->getJar(['foo' => 'bar']); 
+        $this->assertTrue($jar->has('foo'));
+        $this->assertFalse($jar->has('parek'));      
+    }
+}

--- a/tests/Routing/MiddlewareTest.php
+++ b/tests/Routing/MiddlewareTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Lemon\Tests\Routing;
 
 use Lemon\Config\Config;
+use Lemon\Contracts\Http\CookieJar as CookieJarContract;
 use Lemon\Contracts\Http\ResponseFactory as ResponseFactoryContract;
 use Lemon\Contracts\Protection\Csrf as CsrfContract;
 use Lemon\Contracts\Routing\Router as RouterContract;
+use Lemon\Http\CookieJar;
 use Lemon\Http\Request;
 use Lemon\Http\ResponseFactory;
 use Lemon\Http\Responses\HtmlResponse;
@@ -51,6 +53,9 @@ class MiddlewareTest extends TestCase
         $f = new Factory($c, new Compiler($c), $l);
         $r = new Router($l, $rs = new ResponseFactory($f, $l));
 
+        $l->add(CookieJar::class);
+        $l->alias(CookieJarContract::class, CookieJar::class);
+
         $l->add(Request::class, $re = new Request('/', '', 'GET', [], '', [], [], ''));
 
         $l->add(ProtectionCsrf::class);
@@ -65,7 +70,6 @@ class MiddlewareTest extends TestCase
         $l->add(Logger::class);
 
         $r->get('/', fn () => 'foo')->middleware(Csrf::class);
-
 
         $r->get('admin', fn(Logger $logger) => $logger->log('foo'))->middleware([TestingMiddleware::class, 'onlyAuthenticated']);
 


### PR DESCRIPTION
This PR adds CookieJar. CookieJar is class which connects cookies from request and response. Currently if you wanted to read and write cookie, you would have to get the cookie from request and set it to response. Also, setting cookie required having the response which lead to problematic situations such as CSRF middleware.