### PR TITLE
[Validation] Fallback values

### DIFF
--- a/src/Lemon/Http/Request.php
+++ b/src/Lemon/Http/Request.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Lemon\Http;
 
 use Exception;
+use Fiber;
 use Lemon\Kernel\Application;
-use Lemon\Validation\Validator;
+use Lemon\Contracts\Validation\Validator;
 
 class Request
 {
@@ -172,15 +173,17 @@ class Request
      *
      * @throws \Exception When application is not injected
      */
-    public function validate(array $rules): bool
+    public function validate(array $rules, mixed $fallback): void
     {
         if (!$this->application) {
             throw new \Exception('Application is required for validation. Try injecting using ::injectApplication'); // TODO exception
         }
 
-        return $this->application->get(Validator::class)
+        if (!$this->application->get(Validator::class)
             ->validate($this->data(), $rules)
-        ;
+        ) {
+            Fiber::suspend($fallback);
+        }
     }
 
     public function getCookie(string $name): ?string

--- a/src/Lemon/Templating/Template.php
+++ b/src/Lemon/Templating/Template.php
@@ -14,13 +14,24 @@ final class Template
     public function __construct(
         public readonly string $raw_path,
         public readonly string $compiled_path,
-        public readonly array $data
+        private array $data
     ) {
     }
 
     public function __toString(): string
     {
         return $this->render();
+    }
+
+    public function with(...$data): static
+    {
+        $this->data = [...$this->data, ...$data];
+        return $this;
+    }
+
+    public function data(): array
+    {
+        return $this->data;
     }
 
     public function render(): string

--- a/src/Lemon/Testing/TestResponse.php
+++ b/src/Lemon/Testing/TestResponse.php
@@ -48,7 +48,7 @@ final class TestResponse
 
         $this->testCase->assertSame($path, $this->response->body->raw_path);
 
-        $data = $this->response->body->data;
+        $data = $this->response->body->data();
         foreach ($with as $key => $value) {
             if (($data[$key] ?? null) !== $value) {
                 $this->testCase->fail('Failed asserting that template data match');


### PR DESCRIPTION
This PR improves validaton in Request. From now on, Request::validate() won't return bool, but suspend your route callback with given value.

Meaning that instead of

```php
$ok = $request->validate([
    'foo' => 'numeric',
]);

if (!$ok) {
    return 'error';
}
```

you can do just

```php
$request->validate([
    'foo' => 'numeric',
], 'error');
```
