### PR TITLE
[Routing] adds Router::noCsrf()

### DIFF
--- a/src/Lemon/Route.php
+++ b/src/Lemon/Route.php
@@ -22,6 +22,7 @@ namespace Lemon;
  * @method static \Lemon\Routing\Collection controller(string $base, string $controller) Creates collection of given controller
  * @method static \Lemon\Http\Response      dispatch(Request $request)                   Finds route depending on given request.
  * @method static \Lemon\Routing\Collection routes()                                     Returns all routes
+ * @method static \Lemon\Routing\Collection withoutCsrfProtection(callable $routes)                Creates collection without CSRF protection.
  *
  * @see \Lemon\Routing\Router
  */

--- a/src/Lemon/Route.php
+++ b/src/Lemon/Route.php
@@ -22,7 +22,7 @@ namespace Lemon;
  * @method static \Lemon\Routing\Collection controller(string $base, string $controller) Creates collection of given controller
  * @method static \Lemon\Http\Response      dispatch(Request $request)                   Finds route depending on given request.
  * @method static \Lemon\Routing\Collection routes()                                     Returns all routes
- * @method static \Lemon\Routing\Collection withoutCsrfProtection(callable $routes)                Creates collection without CSRF protection.
+ * @method static \Lemon\Routing\Collection withoutCsrfProtection(callable $routes)      Creates collection without CSRF protection.
  *
  * @see \Lemon\Routing\Router
  */

--- a/src/Lemon/Routing/Router.php
+++ b/src/Lemon/Routing/Router.php
@@ -182,7 +182,7 @@ class Router implements RouterContract
         })->prefix($base);
     }
 
-    public function noCsrf(callable $routes): Collection
+    public function withoutCsrf(callable $routes): Collection
     {
         return $this->collection($routes)->exclude(Csrf::class);
     }

--- a/src/Lemon/Routing/Router.php
+++ b/src/Lemon/Routing/Router.php
@@ -11,6 +11,7 @@ use Lemon\Http\Request;
 use Lemon\Http\Response;
 use Lemon\Http\Responses\EmptyResponse;
 use Lemon\Kernel\Application;
+use Lemon\Protection\Middlwares\Csrf;
 use Lemon\Routing\Attributes\AfterAction;
 use Lemon\Routing\Attributes\BeforeAction;
 use Lemon\Routing\Exceptions\RouteException;
@@ -179,6 +180,11 @@ class Router implements RouterContract
                 }
             }
         })->prefix($base);
+    }
+
+    public function noCsrf(callable $routes): Collection
+    {
+        return $this->collection($routes)->exclude(Csrf::class);
     }
 
     /**

--- a/src/Lemon/Routing/Router.php
+++ b/src/Lemon/Routing/Router.php
@@ -182,7 +182,10 @@ class Router implements RouterContract
         })->prefix($base);
     }
 
-    public function withoutCsrf(callable $routes): Collection
+    /**
+     * Creates collection without CSRF protection.
+     */
+    public function withoutCsrfProtection(callable $routes): Collection
     {
         return $this->collection($routes)->exclude(Csrf::class);
     }


### PR DESCRIPTION
This PR adds new router method Router::noCsrf() which basically excludes CSRF middleware in given routes. Before merging I need to consider name.