### PR TITLE
[Container] adds injectable classes

### DIFF
--- a/Untitled
+++ b/Untitled
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemon\Tests\Kernel\Resources\Units;
+
+class User
+{
+
+}

--- a/src/Lemon/Contracts/Kernel/Injectable.php
+++ b/src/Lemon/Contracts/Kernel/Injectable.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemon\Contracts\Kernel;
+
+use Lemon\Kernel\Container;
+
+interface Injectable
+{
+    /**
+     * Creates new instance from injection value.
+     */
+    public static function fromInjection(Container $container, mixed $value): self;
+}

--- a/tests/Kernel/ContainerTest.php
+++ b/tests/Kernel/ContainerTest.php
@@ -11,6 +11,8 @@ use Lemon\Tests\Kernel\Resources\IFoo;
 use Lemon\Tests\Kernel\Resources\Units\Bar;
 use Lemon\Tests\Kernel\Resources\Units\Baz;
 use Lemon\Tests\Kernel\Resources\Units\Foo;
+use Lemon\Tests\Kernel\Resources\Units\User;
+use Lemon\Tests\Kernel\Resources\Units\UserFactory;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -90,5 +92,28 @@ class ContainerTest extends TestCase
             Fiber::suspend(3);
             return 4;
         }, []));
+    }
+
+    public function testIsInjectable()
+    {
+        $container = new Container();
+        $this->assertTrue($container->isInjectable(User::class));
+    }
+
+    public function testInjectables()
+    {
+        $container = new Container();
+        $container->add(UserFactory::class);
+
+        $this->assertThat(
+            $container->get(User::class, 'frajer'), 
+            $this->equalTo(new User(1, 'frajer'))
+        );
+
+        $this->assertThat(
+            $container->call(fn(User $user) => $user, ['user' => 'frajer']), 
+            $this->equalTo(new User(1, 'frajer'))
+        );
+
     }
 }

--- a/tests/Kernel/Resources/Units/User.php
+++ b/tests/Kernel/Resources/Units/User.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemon\Tests\Kernel\Resources\Units;
+
+use Lemon\Contracts\Kernel\Injectable;
+use Lemon\Kernel\Container;
+
+class User implements Injectable
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $name,
+    ) {
+
+    }
+
+    public static function fromInjection(Container $container, mixed $value): self
+    {
+        return $container->get(UserFactory::class)->make($value);
+    }
+}

--- a/tests/Kernel/Resources/Units/UserFactory.php
+++ b/tests/Kernel/Resources/Units/UserFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lemon\Tests\Kernel\Resources\Units;
+
+class UserFactory
+{
+    public function make(string $name): User
+    {
+        return new User(1, $name);
+    }
+}


### PR DESCRIPTION
This PR adds injectable classes to container, that have their biggest impact on `Container::call`, because till now, you could pass some values, which would be passed along with injected ones. Now, if param has type that implements `\Lemon\Contracts\Kernel\Injectable`, it would (instead of just passing the value) convert passed value into given type via `Injectable::fromInjection` static method. 

Example

```php 
Route::get('/users/{user}', function(User $user) {
    return $user;
});
```

and `User` looks like this:

```php
class User implements Injectable
{
    public static function fromInjection(Container $container, mixed $value): self
    {
        return $container->get(UserFactory::class)->get($value);
    }
}
```

It basicaly converts the value into provided type with container.