### PR TITLE
[Templating] renders templates in isolation

### DIFF
--- a/src/Lemon/Templating/Template.php
+++ b/src/Lemon/Templating/Template.php
@@ -38,18 +38,17 @@ final class Template
     {
         ob_start();
 
-        $data = $this->data;
-
-        extract($data);
-
         try {
-            require $this->compiled_path;
+            (function($data) {
+				extract($data);
+				require $this->compiled_path;
+			})($this->data);
         } catch (\Throwable $e) {
             ob_get_clean();
 
             throw TemplateException::from($e, $this->raw_path);
         }
 
-        return ob_get_clean();
+		return ob_get_clean();
     }
 }

--- a/tests/Templating/Juice/Compilers/Directives/Layout/LayoutTest.php
+++ b/tests/Templating/Juice/Compilers/Directives/Layout/LayoutTest.php
@@ -6,6 +6,7 @@ namespace Lemon\Tests\Templating\Juice\Compilers\Directives\Layout;
 
 use Lemon\Templating\Exceptions\TemplateException;
 use Lemon\Templating\Juice\Compilers\Directives\Layout\Layout;
+use Lemon\Templating\Template;
 use Lemon\Tests\TestCase;
 
 /**
@@ -18,9 +19,8 @@ class LayoutTest extends TestCase
     public function testRendering()
     {
         $data = ['foo' => '10'];
-        ob_start();
-        $this->render(__DIR__.DIRECTORY_SEPARATOR.'templates'.DIRECTORY_SEPARATOR.'foo.php', $data);
-        $result = ob_get_clean();
+        $path = __DIR__.DIRECTORY_SEPARATOR.'templates'.DIRECTORY_SEPARATOR.'foo.php';
+        $result = new Template($path, $path, $data);
         $this->assertSame(<<<'HTML'
 
 
@@ -28,7 +28,7 @@ class LayoutTest extends TestCase
 
         <p>bar</p>
 
-        HTML, $result);
+        HTML, $result->render());
 
         $this->assertThrowable(function () {
             $l = new FakeLayout('foo');
@@ -47,13 +47,6 @@ class LayoutTest extends TestCase
             $l = new FakeLayout('foo');
             $l->yield('parek');
         }, TemplateException::class);
-    }
-
-    private function render(string $file, array $data): void
-    {
-        extract($data);
-
-        include $file;
     }
 }
 


### PR DESCRIPTION
This PR adds isolation to template rendering, which is just fancy word for fixig bug in rendering layouts. Now when you use layouts, Template::render should return output, instead of write to stdout.