### PR TITLE
[HTTP] adds Request::mustBe

### DIFF
--- a/src/Lemon/Http/Request.php
+++ b/src/Lemon/Http/Request.php
@@ -120,6 +120,15 @@ class Request
         return !$this->is($content_type);
     }
 
+    public function mustBe(string $content_type, mixed $fallback): static
+    {
+        if (!$this->is($content_type)) {
+            \Fiber::suspend($fallback);
+        }
+
+        return $this;
+    }
+
     /**
      * Adds request parsing function.
      */
@@ -196,7 +205,7 @@ class Request
         return isset($this->cookies[$name]);
     }
 
-    public function cookies()
+    public function cookies(): array
     {
         return $this->cookies;
     }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -152,4 +152,23 @@ class RequestTest extends TestCase
         $this->assertNull($f->start($r));
         $this->assertSame('bar', $f->getReturn());
     }
+
+    public function testMustBe(): void
+    {
+        $r = new Request('/', '', 'GET', ['Content-Type' => 'application/json'], '{"foo":10}', [], [], '');
+        $f = new \Fiber(function(Request $r) {
+            $r->mustBe('application/parek', 'foo');
+            return 'bar';
+        });
+
+        $this->assertSame('foo', $f->start($r));
+
+        $f = new \Fiber(function(Request $r) {
+            $r->mustBe('application/json', 'foo');
+            return 'bar';
+        });
+
+        $this->assertNull($f->start($r));
+        $this->assertSame('bar', $f->getReturn());
+    }
 }


### PR DESCRIPTION
This PR adds method `mustBe` to `Request`. It suspends parent fiber (mostly route callback) when request is not given content-type.

:nail_care: 

```php
// instead of
Route::post("/users/add", function(Request $r) {
    if ($request->aint('application/json')) {
         return 'error';
    }
    // ...
});

// you can do just
Route::post("/users/add", function(Request $r) {
    $request->mustBe('application/json'), 'error');
    // ...
});