### PR TITLE
[Routing] Prioritize static routes

### DIFF
--- a/src/Lemon/Routing/Collection.php
+++ b/src/Lemon/Routing/Collection.php
@@ -120,31 +120,41 @@ class Collection
         }
         foreach ($this->routes as $route) {
             if ($route instanceof Collection) {
-                if (!is_null($found = $route->dispatch($path))) {
-                    if ($this->exclude) {
-                        $found[0]->exclude(...$this->exclude);
-                    }
-
-                    if ($this->middlewares) {
-                        $found[0]->middleware(...$this->middlewares);
-                    }
-
-                    return $found;
+                if (is_null($found = $route->dispatch($path))) {
+                    continue;
                 }
+            
+                if ($this->exclude) {
+                    $found[0]->exclude(...$this->exclude);
+                }
+
+                if ($this->middlewares) {
+                    $found[0]->middleware(...$this->middlewares);
+                }
+
+                return $found;
             }
 
             if ($route instanceof Route) {
-                if (!is_null($found = $route->matches($path))) {
-                    if ($this->exclude) {
-                        $route->exclude(...$this->exclude);
-                    }
-
-                    if ($this->middlewares) {
-                        $route->middleware(...$this->middlewares);
-                    }
-
-                    return [$route, $found];
+                if (is_null($found = $route->matches($path))) {
+                    continue;
                 }
+
+                if ($found !== []
+                    && isset($this->routes[$path])
+                ) {
+                    continue;
+                }
+
+                if ($this->exclude) {
+                    $route->exclude(...$this->exclude);
+                }
+
+                if ($this->middlewares) {
+                    $route->middleware(...$this->middlewares);
+                }
+
+                return [$route, $found];
             }
         }
 

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -148,6 +148,20 @@ class RouterTest extends TestCase
 
         $this->assertThat($r->dispatch($this->emulate('/foo/baz', 'GET')), $this->equalTo(new HtmlResponse('foobaz')));
         $this->assertThat($r->dispatch($this->emulate('/foo/bar', 'GET')), $this->equalTo(new HtmlResponse('bar')));
+
+        $r = $this->getRouter();
+        $r->collection(function() use ($r) {
+            $r->get('{bar}', fn($bar) => $bar);
+            $r->get('baz', fn() => 'foobaz');
+            $r->get('{bar}/baz/{foo}', fn($bar, $foo) => $bar.$foo);
+            $r->get('baz/baz/foo', fn() => 'parek v rohliku');
+        })->prefix('foo');
+
+        $this->assertThat($r->dispatch($this->emulate('/foo/baz', 'GET')), $this->equalTo(new HtmlResponse('foobaz')));
+        $this->assertThat($r->dispatch($this->emulate('/foo/bar', 'GET')), $this->equalTo(new HtmlResponse('bar')));
+        $this->assertThat($r->dispatch($this->emulate('/foo/baz/baz/foo', 'GET')), $this->equalTo(new HtmlResponse('parek v rohliku')));
+        $this->assertThat($r->dispatch($this->emulate('/foo/bar/baz/foo', 'GET')), $this->equalTo(new HtmlResponse('barfoo')));
+
     }
 }
 

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -145,9 +145,11 @@ class RouterTest extends TestCase
         $r = $this->getRouter();
         $r->get('/foo/{bar}', fn($bar) => $bar);
         $r->get('/foo/baz', fn() => 'foobaz');
+        $r->get('foo', fn() => 'foo');
 
         $this->assertThat($r->dispatch($this->emulate('/foo/baz', 'GET')), $this->equalTo(new HtmlResponse('foobaz')));
         $this->assertThat($r->dispatch($this->emulate('/foo/bar', 'GET')), $this->equalTo(new HtmlResponse('bar')));
+        $this->assertThat($r->dispatch($this->emulate('/foo', 'GET')), $this->equalTo(new HtmlResponse('foo')));
 
         $r = $this->getRouter();
         $r->collection(function() use ($r) {
@@ -160,7 +162,7 @@ class RouterTest extends TestCase
         $this->assertThat($r->dispatch($this->emulate('/foo/baz', 'GET')), $this->equalTo(new HtmlResponse('foobaz')));
         $this->assertThat($r->dispatch($this->emulate('/foo/bar', 'GET')), $this->equalTo(new HtmlResponse('bar')));
         $this->assertThat($r->dispatch($this->emulate('/foo/baz/baz/foo', 'GET')), $this->equalTo(new HtmlResponse('parek v rohliku')));
-        $this->assertThat($r->dispatch($this->emulate('/foo/bar/baz/foo', 'GET')), $this->equalTo(new HtmlResponse('barfoo')));
+        $this->assertThat($r->dispatch($this->emulate('/foo/rizek/baz/parek', 'GET')), $this->equalTo(new HtmlResponse('rizekparek')));
 
     }
 }

--- a/tests/Routing/RouterTest.php
+++ b/tests/Routing/RouterTest.php
@@ -139,6 +139,16 @@ class RouterTest extends TestCase
         $this->assertThat($r->dispatch($this->emulate('foo', 'GET')), $this->equalTo(new TemplateResponse(new Template($path, $path, ['code' => 404]), 404)));
         $this->assertThat($r->dispatch($this->emulate('/', 'POST')), $this->equalTo(new TemplateResponse(new Template($path, $path, ['code' => 400]), 400)));
     }
+
+    public function testPriorityOfStaticRoutes()
+    {
+        $r = $this->getRouter();
+        $r->get('/foo/{bar}', fn($bar) => $bar);
+        $r->get('/foo/baz', fn() => 'foobaz');
+
+        $this->assertThat($r->dispatch($this->emulate('/foo/baz', 'GET')), $this->equalTo(new HtmlResponse('foobaz')));
+        $this->assertThat($r->dispatch($this->emulate('/foo/bar', 'GET')), $this->equalTo(new HtmlResponse('bar')));
+    }
 }
 
 class SimpleCompiler implements Compiler


### PR DESCRIPTION
When working with dynamic routes, you can have situation where your static route is treated as dynamic. For example if I have routes `foo/{bar}` and `foo/baz`and visit `/foo/baz` it will treat it as dynamic route `foo/{bar}` and call its callback. This PR fixes it so now you static routes have higher priority.